### PR TITLE
Several fixes / improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ jack = ["jack-sys"]
 
 [dependencies]
 bitflags = "0.3"
+enum_primitive = "*"
+num = "*"
 
 [target.i686-unknown-linux-gnu.dependencies]
 alsa-sys = "0.0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,6 @@ jack = ["jack-sys"]
 
 [dependencies]
 bitflags = "0.3"
-enum_primitive = "*"
-num = "*"
 
 [target.i686-unknown-linux-gnu.dependencies]
 alsa-sys = "0.0.8"

--- a/src/backend/winmm/handler.rs
+++ b/src/backend/winmm/handler.rs
@@ -6,7 +6,7 @@ use winmm_sys::midiInAddBuffer;
 use super::HandlerData;
 use ::Ignore;
 
-pub extern "C" fn handle_input<T>(_: HMIDIIN,
+pub extern "system" fn handle_input<T>(_: HMIDIIN,
                 input_status: UINT, 
                 instance_ptr: DWORD_PTR,
                 midi_message: DWORD_PTR,

--- a/src/backend/winmm/handler.rs
+++ b/src/backend/winmm/handler.rs
@@ -46,15 +46,16 @@ pub extern "C" fn handle_input<T>(_: HMIDIIN,
         } else { 1 };
         
         // Copy bytes to our MIDI message.
-        let ptr = (&midi_message) as *const DWORD_PTR as *const u8;
+        //let ptr = (&midi_message) as *const u64 as *const u8;
+        let ptr = (&midi_message) as *const _ as *const u8;
         let bytes: &[u8] = unsafe { slice::from_raw_parts(ptr, nbytes as usize) };
-        data.message.bytes.push_all(bytes);
+        data.message.bytes.extend_from_slice(bytes);
     } else { // Sysex message (MIM_LONGDATA or MIM_LONGERROR)
         let sysex = unsafe { &*(midi_message as *const MIDIHDR) };
         if !data.ignore_flags.contains(Ignore::Sysex) && input_status != MM_MIM_LONGERROR {
             // Sysex message and we're not ignoring it
             let bytes: &[u8] = unsafe { slice::from_raw_parts(sysex.lpData as *const u8, sysex.dwBytesRecorded as usize) };
-            data.message.bytes.push_all(bytes);
+            data.message.bytes.extend_from_slice(bytes);
             // TODO: If sysex messages are longer than RT_SYSEX_BUFFER_SIZE, they
             //       are split in chunks. We could reassemble a single message.
         }

--- a/src/backend/winmm/mod.rs
+++ b/src/backend/winmm/mod.rs
@@ -30,7 +30,7 @@ use winmm_sys::{
     midiOutShortMsg,
 };
 
-use ::{MidiMessage, Ignore};
+use ::{MidiMessage, MidiShortMessage, Ignore};
 use ::errors::*;
 
 mod handler;
@@ -359,9 +359,9 @@ impl MidiOutputConnection {
         }
         Ok(())
     }
-    pub fn send(&mut self, message: MidiShortMessage) -> Result<(), SendError> {
+    pub fn sendShortMessage(&mut self, message: MidiShortMessage) -> Result<(), SendError> {
         loop {
-            let result = unsafe { midiOutShortMsg(self.out_handle, message.to_u32() as DWORD) };
+            let result = unsafe { midiOutShortMsg(self.out_handle, message.to_u32()) };
             if result == MIDIERR_NOTREADY {
                 sleep_ms(1);
                 continue;

--- a/src/backend/winmm/mod.rs
+++ b/src/backend/winmm/mod.rs
@@ -101,7 +101,7 @@ impl MidiInput {
         // Next lines added to add the portNumber to the name so that 
         // the device's names are sure to be listed with individual names
         // even when they have the same brand name
-        let _ = write!(&mut output, " {}", port_number);
+        //let _ = write!(&mut output, " {}", port_number);
         Ok(output)
     }
     
@@ -254,7 +254,7 @@ impl MidiOutput {
         // Next lines added to add the portNumber to the name so that 
         // the device's names are sure to be listed with individual names
         // even when they have the same brand name
-        let _ = write!(&mut output, " {}", port_number);
+        //let _ = write!(&mut output, " {}", port_number);
         Ok(output)
     }
     

--- a/src/backend/winmm/mod.rs
+++ b/src/backend/winmm/mod.rs
@@ -3,7 +3,8 @@ use std::ffi::OsString;
 use std::os::windows::ffi::OsStringExt;
 use std::sync::{Mutex};
 use std::io::{stderr, Write};
-use std::thread::sleep_ms;
+use std::thread::sleep;
+use std::time::Duration;
 use alloc::heap;
 
 use winapi::*;
@@ -30,7 +31,7 @@ use winmm_sys::{
     midiOutShortMsg,
 };
 
-use ::{MidiMessage, ShortMessage, Ignore};
+use ::{MidiMessage, Ignore};
 use ::errors::*;
 
 mod handler;
@@ -317,7 +318,7 @@ impl MidiOutputConnection {
             loop {
                 let result = unsafe { midiOutLongMsg(self.out_handle, &mut sysex, mem::size_of::<MIDIHDR>() as u32) };
                 if result == MIDIERR_NOTREADY {
-                    sleep_ms(1);
+                    sleep(Duration::from_millis(1));
                     continue;
                 } else {
                     if result != MMSYSERR_NOERROR {
@@ -330,7 +331,7 @@ impl MidiOutputConnection {
             loop {
                 let result = unsafe { midiOutUnprepareHeader(self.out_handle, &mut sysex, mem::size_of::<MIDIHDR>() as u32) };
                 if result == MIDIERR_STILLPLAYING {
-                    sleep_ms(1);
+                    sleep(Duration::from_millis(1));
                     continue;
                 } else { break; }
             }
@@ -351,7 +352,7 @@ impl MidiOutputConnection {
             loop {
                 let result = unsafe { midiOutShortMsg(self.out_handle, packet) };
                 if result == MIDIERR_NOTREADY {
-                    sleep_ms(1);
+                    sleep(Duration::from_millis(1));
                     continue;
                 } else {
                     if result != MMSYSERR_NOERROR {
@@ -363,11 +364,11 @@ impl MidiOutputConnection {
         }
         Ok(())
     }
-    pub fn send_short_message(&mut self, message: ShortMessage) -> Result<(), SendError> {
+    pub fn send_short_message(&mut self, message: u32) -> Result<(), SendError> {
         loop {
-            let result = unsafe { midiOutShortMsg(self.out_handle, message.to_u32()) };
+            let result = unsafe { midiOutShortMsg(self.out_handle, message) };
             if result == MIDIERR_NOTREADY {
-                sleep_ms(1);
+                sleep(Duration::from_millis(1));
                 continue;
             } else {
                 if result != MMSYSERR_NOERROR {

--- a/src/backend/winmm/mod.rs
+++ b/src/backend/winmm/mod.rs
@@ -236,8 +236,6 @@ impl MidiOutput {
     }
     
     pub fn port_name(&self, port_number: u32) -> Result<String, PortInfoError> {
-        //use std::fmt::Write;
-        
         let mut device_caps: MIDIOUTCAPSW = unsafe { mem::uninitialized() };
         let result = unsafe { midiOutGetDevCapsW(port_number as UINT_PTR, &mut device_caps, mem::size_of::<MIDIINCAPSW>() as u32) };
         if result == MMSYSERR_BADDEVICEID {
@@ -245,13 +243,7 @@ impl MidiOutput {
         } else if result == MMSYSERR_ERROR {
             return Err(PortInfoError::CannotRetrievePortName);
         }
-        //assert!(result == MMSYSERR_NOERROR, "could not retrieve Windows MM MIDI output port name");
-        let /*mut*/ output = from_wide_ptr(device_caps.szPname.as_ptr(), device_caps.szPname.len()).to_string_lossy().into_owned();
-        
-        // Next lines added to add the portNumber to the name so that 
-        // the device's names are sure to be listed with individual names
-        // even when they have the same brand name
-        //let _ = write!(&mut output, " {}", port_number);
+        let output = from_wide_ptr(device_caps.szPname.as_ptr(), device_caps.szPname.len()).to_string_lossy().into_owned();
         Ok(output)
     }
     

--- a/src/backend/winmm/mod.rs
+++ b/src/backend/winmm/mod.rs
@@ -357,7 +357,21 @@ impl MidiOutputConnection {
                 }
             }
         }
-        
+        Ok(())
+    }
+    pub fn send(&mut self, message: MidiShortMessage) -> Result<(), SendError> {
+        loop {
+            let result = unsafe { midiOutShortMsg(self.out_handle, message.to_u32() as DWORD) };
+            if result == MIDIERR_NOTREADY {
+                sleep_ms(1);
+                continue;
+            } else {
+                if result != MMSYSERR_NOERROR {
+                    return Err(SendError::Other("sending non-sysex message failed"));
+                }
+                break;
+            }
+        }
         Ok(())
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -127,7 +127,7 @@ impl MidiOutputConnection {
     }
 
     #[cfg(target_os="windows")]
-    pub fn sendShortMessage(&mut self, message: ::MidiShortMessage) -> Result<(), SendError> {
-        self.imp.sendShortMessage(message)
+    pub fn send_short_message(&mut self, message: ::ShortMessage) -> Result<(), SendError> {
+        self.imp.send_short_message(message)
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -125,4 +125,9 @@ impl MidiOutputConnection {
     pub fn send(&mut self, message: &[u8]) -> Result<(), SendError> {
         self.imp.send(message)
     }
+
+    #[cfg(target_os="windows")]
+    pub fn sendShortMessage(&mut self, message: ::MidiShortMessage) -> Result<(), SendError> {
+        self.imp.sendShortMessage(message)
+    }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -127,7 +127,7 @@ impl MidiOutputConnection {
     }
 
     #[cfg(target_os="windows")]
-    pub fn send_short_message(&mut self, message: ::ShortMessage) -> Result<(), SendError> {
+    pub fn send_short_message(&mut self, message: u32) -> Result<(), SendError> {
         self.imp.send_short_message(message)
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,12 +21,14 @@ impl fmt::Display for InitError {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PortInfoError {
     PortNumberOutOfRange,
+    CannotRetrievePortName,
 }
 
 impl Error for PortInfoError {
     fn description(&self) -> &str {
         match *self {
             PortInfoError::PortNumberOutOfRange => PORT_OUT_OF_RANGE_MSG,
+            PortInfoError::CannotRetrievePortName => "could not retrieve Windows MM MIDI output port name",
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,10 +68,10 @@ pub struct MidiShortMessage {
 	pub data2: u8,
 }
 impl MidiShortMessage {
-	fn to_i32(&self) -> i32 {
-		((((self.data2 as i32) << 16) & 0xFF0000) |
-		  (((self.data1 as i32) << 8) & 0xFF00) |
-		  ((self.status as u8 as i32) & 0xFF)) as i32
+	pub fn to_u32(&self) -> u32 {
+		((((self.data2 as u32) << 16) & 0xFF0000) |
+		  (((self.data1 as u32) << 8) & 0xFF00) |
+		  ((self.status as u8 as u32) & 0xFF)) as u32
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,6 @@
 
 #[macro_use]
 extern crate bitflags;
-#[macro_use]
-extern crate enum_primitive;
 
 #[cfg(target_os="linux")]
 extern crate libc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,37 @@ impl MidiMessage {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct MidiShortMessage {
+	pub status: Status,
+	pub data1: u8,
+	pub data2: u8,
+}
+impl MidiShortMessage {
+	fn to_i32(&self) -> i32 {
+		((((self.data2 as i32) << 16) & 0xFF0000) |
+		  (((self.data1 as i32) << 8) & 0xFF00) |
+		  ((self.status as u8 as i32) & 0xFF)) as i32
+	}
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Status {
+    NoteOn = 0x90,
+    NoteOff = 0x80,
+    ControlChange = 0xB0,
+    PitchBend = 0xE0,
+    ProgramChange = 0xC0,
+    Other(u8)
+}
+
+impl Into<u8> for Status {
+    fn into(self) -> u8 {
+        self as u8
+    }
+}
+
 pub mod os; // include platform-specific behaviour
 
 mod errors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,14 @@ impl MidiShortMessage {
 	}
 }
 
+use std::fmt;
+impl fmt::Display for MidiShortMessage {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "(0x{:X}, {}, {}, {})", self.status & 0xF0, (self.status & 0x0F) + 1, self.data1, self.data2)
+    }
+}
+
+
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Status {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,62 +63,6 @@ impl MidiMessage {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct ShortMessage {
-	pub status: u8,
-	pub data1: u8,
-	pub data2: u8,
-}
-impl ShortMessage {
-	pub fn to_u32(&self) -> u32 {
-		((((self.data2 as u32) << 16) & 0xFF0000) |
-		  (((self.data1 as u32) << 8) & 0xFF00) |
-		  ((self.status as u32) & 0xFF)) as u32
-	}
-	pub fn status(&self) -> u8 {
-		self.status & 0xf0
-	}
-	pub fn channel(&self) -> u8 {
-		self.status & 0x0f
-	}
-}
-
-use std::fmt;
-impl fmt::Display for ShortMessage {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "(0x{:X}, {}, {}, {})", self.status & 0xF0, (self.status & 0x0F) + 1, self.data1, self.data2)
-    }
-}
-
-enum_from_primitive! {
-#[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum Status {
-    // voice
-    NoteOff = 0x80,
-    NoteOn = 0x90,
-    PolyphonicAftertouch = 0xA0,
-    ControlChange = 0xB0,
-    ProgramChange = 0xC0,
-    ChannelAftertouch = 0xD0,
-    PitchBend = 0xE0,
-
-    // sysex
-    SysExStart = 0xF0,
-    MIDITimeCodeQtrFrame = 0xF1,
-    SongPositionPointer = 0xF2,
-    SongSelect = 0xF3,
-    TuneRequest = 0xF6, // F4 anf 5 are reserved and unused
-    SysExEnd = 0xF7,
-    TimingClock = 0xF8,
-    Start = 0xFA,
-    Continue = 0xFB,
-    Stop = 0xFC,
-    ActiveSensing = 0xFE, // FD also res/unused
-    SystemReset = 0xFF,
-}
-}
-
 pub mod os; // include platform-specific behaviour
 
 mod errors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
-#![cfg_attr(windows, feature(vec_push_all, alloc, heap_api))]
+#![cfg_attr(windows, feature(alloc, heap_api))]
 
 #[macro_use]
 extern crate bitflags;
+#[macro_use]
+extern crate enum_primitive;
 
 #[cfg(target_os="linux")]
 extern crate libc;
@@ -62,12 +64,12 @@ impl MidiMessage {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct MidiShortMessage {
+pub struct ShortMessage {
 	pub status: u8,
 	pub data1: u8,
 	pub data2: u8,
 }
-impl MidiShortMessage {
+impl ShortMessage {
 	pub fn to_u32(&self) -> u32 {
 		((((self.data2 as u32) << 16) & 0xFF0000) |
 		  (((self.data1 as u32) << 8) & 0xFF00) |
@@ -76,22 +78,39 @@ impl MidiShortMessage {
 }
 
 use std::fmt;
-impl fmt::Display for MidiShortMessage {
+impl fmt::Display for ShortMessage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "(0x{:X}, {}, {}, {})", self.status & 0xF0, (self.status & 0x0F) + 1, self.data1, self.data2)
     }
 }
 
-
+enum_from_primitive! {
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Status {
-    NoteOn = 0x90,
+    // voice
     NoteOff = 0x80,
+    NoteOn = 0x90,
+    PolyphonicAftertouch = 0xA0,
     ControlChange = 0xB0,
-    PitchBend = 0xE0,
     ProgramChange = 0xC0,
-    // TODO: implement the rest
+    ChannelAftertouch = 0xD0,
+    PitchBend = 0xE0,
+
+    // sysex
+    SysExStart = 0xF0,
+    MIDITimeCodeQtrFrame = 0xF1,
+    SongPositionPointer = 0xF2,
+    SongSelect = 0xF3,
+    TuneRequest = 0xF6, // F4 anf 5 are reserved and unused
+    SysExEnd = 0xF7,
+    TimingClock = 0xF8,
+    Start = 0xFA,
+    Continue = 0xFB,
+    Stop = 0xFC,
+    ActiveSensing = 0xFE, // FD also res/unused
+    SystemReset = 0xFF,
+}
 }
 
 pub mod os; // include platform-specific behaviour

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,12 @@ impl ShortMessage {
 		  (((self.data1 as u32) << 8) & 0xFF00) |
 		  ((self.status as u32) & 0xFF)) as u32
 	}
+	pub fn status(&self) -> u8 {
+		self.status & 0xf0
+	}
+	pub fn channel(&self) -> u8 {
+		self.status & 0x0f
+	}
 }
 
 use std::fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ impl MidiMessage {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MidiShortMessage {
-	pub status: Status,
+	pub status: u8,
 	pub data1: u8,
 	pub data2: u8,
 }
@@ -71,7 +71,7 @@ impl MidiShortMessage {
 	pub fn to_u32(&self) -> u32 {
 		((((self.data2 as u32) << 16) & 0xFF0000) |
 		  (((self.data1 as u32) << 8) & 0xFF00) |
-		  ((self.status as u8 as u32) & 0xFF)) as u32
+		  ((self.status as u32) & 0xFF)) as u32
 	}
 }
 
@@ -83,13 +83,7 @@ pub enum Status {
     ControlChange = 0xB0,
     PitchBend = 0xE0,
     ProgramChange = 0xC0,
-    Other(u8)
-}
-
-impl Into<u8> for Status {
-    fn into(self) -> u8 {
-        self as u8
-    }
+    // TODO: implement the rest
 }
 
 pub mod os; // include platform-specific behaviour


### PR DESCRIPTION
Several fixes / improvements:
- On windows, midiInOpen() only succeeds when callback is extern "system", so I changed it to that. Now it works.
- Improved error handling when getting port name: Under some conditions (such as when MidiHub is installed but not running), getting the portname can fail, but only for the MidiHub port! Before it crashed because of assert, now it handles this case gracefully. The reason this is necessary is because often you want to list all input or output port names, allowing the user to choose one. This should just ignore the port names that cannot be queried, for example:
```rust
		let midi_out = try!(MidiOutput::new(""));
		let port_out = try!((|| {
			for i in 0..midi_out.port_count() {
				if let Ok(name) = midi_out.port_name(i) {
					if name == cfg.port_name {
						return Some(i);
					}
				}
			}
			return None;
		})().ok_or(r#"midi output port not found"#));
```
- A similar issue is: port names should be reported *as they appear in the OS*, without any added number! The UI can add a number if that's wanted. The reason, seen above, is that the port can be given by name in a config file that the app stores. Port numbers change when devices get added or removed, port names stay the same. So this method of finding the port name by name rather than number between app sessions is more robust, but it *requires* that the api returns the name without added number!
- Some small things like sleep(Duration::from_millis(1)); instead of sleep_ms and extend_from_slice() instead of push_all().
- Most of the time when you want to send midi messages, they are MIDI Short Messages, being expressible in 3 bytes. It is wasteful to allocate a vector and iterate through it and deallocate it for each short message, especially when you are sending a lot of MIDI messages, so I added a function to send MIDI Short Messages expressed in a u32, that can send them directly without any conversion necessary.
```rust
pub fn send_short_message(&mut self, message: u32) -> Result<(), SendError>
```
Most likely in your app you will have a type for MIDI Short Messages anyway.
It will have a method to_u32():
```rust
#[derive(Clone, Copy, Debug, PartialEq)]
pub struct ShortMsg {
	pub data0: u8,
	pub data1: u8,
	pub data2: u8,
}
impl ShortMsg {
	pub fn status(&self) -> Status { // Status and masks are from the rimd crate
		Status::from_u8(self.data0 & STATUS_MASK).unwrap()
	}
	pub fn channel(&self) -> u8 {
		self.data0 & CHANNEL_MASK
	}
	pub fn to_u32(&self) -> u32 {
		((((self.data2 as u32) << 16) & 0xFF0000) |
		  (((self.data1 as u32) << 8) & 0xFF00) |
		  ((self.data0 as u32) & 0xFF)) as u32
	}
	...
	// different constructors here for the different types of short msgs
}
```
Since I'm on windows, I only implemented this for windows, but I'm sure it's easy to add it for other OSes, too.

Btw, this crate goes well together with the rimd crate :)
Maybe it would make sense to unify them into one project in the future..
