### PR TITLE
Update to winapi 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,4 @@ libc = "0.2.21"
 coremidi = "0.3.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2.4"
-winmm-sys = "0.2.0"
+winapi = { version = "0.3", features = ["mmsystem", "mmeapi"] }

--- a/src/backend/winmm/handler.rs
+++ b/src/backend/winmm/handler.rs
@@ -1,10 +1,13 @@
 use std::{mem, slice};
-use std::io::{Write, stderr}; 
+use std::io::{Write, stderr};
 
-use super::winapi::*;
-use super::winmm_sys::midiInAddBuffer;
+use super::winapi::shared::basetsd::DWORD_PTR;
+use super::winapi::shared::minwindef::{DWORD, UINT};
+use super::winapi::um::mmeapi::midiInAddBuffer;
+use super::winapi::um::mmsystem::{HMIDIIN, MIDIHDR, MMSYSERR_NOERROR, MM_MIM_DATA,
+                                  MM_MIM_LONGDATA, MM_MIM_LONGERROR};
 use super::HandlerData;
-use ::Ignore;
+use Ignore;
 
 pub extern "system" fn handle_input<T>(_: HMIDIIN,
                 input_status: UINT, 

--- a/src/backend/winmm/mod.rs
+++ b/src/backend/winmm/mod.rs
@@ -1,41 +1,30 @@
 extern crate winapi;
-extern crate winmm as winmm_sys;
 
 use std::{mem, ptr, slice};
 use std::ffi::OsString;
 use std::os::windows::ffi::OsStringExt;
 use std::sync::Mutex;
-use std::io::{stderr, Write};
+use std::io::{Write, stderr};
 use std::thread::sleep;
 use std::time::Duration;
 use memalloc::{allocate, deallocate};
 
-use self::winapi::*;
+use self::winapi::shared::basetsd::{DWORD_PTR, UINT_PTR};
+use self::winapi::shared::minwindef::{DWORD, UINT};
 
-use self::winmm_sys::{
-    midiInGetNumDevs,
-    midiInGetDevCapsW,
-    midiInOpen,
-    midiInStart,
-    midiInClose,
-    midiInReset,
-    midiInStop,
-    midiInAddBuffer,
-    midiInPrepareHeader,
-    midiInUnprepareHeader,
-    midiOutGetNumDevs,
-    midiOutGetDevCapsW,
-    midiOutOpen,
-    midiOutReset,
-    midiOutClose,
-    midiOutPrepareHeader,
-    midiOutUnprepareHeader,
-    midiOutLongMsg,
-    midiOutShortMsg,
-};
+use self::winapi::um::mmeapi::{midiInAddBuffer, midiInClose, midiInGetDevCapsW, midiInGetNumDevs,
+                               midiInOpen, midiInPrepareHeader, midiInReset, midiInStart,
+                               midiInStop, midiInUnprepareHeader, midiOutClose,
+                               midiOutGetDevCapsW, midiOutGetNumDevs, midiOutLongMsg, midiOutOpen,
+                               midiOutPrepareHeader, midiOutReset, midiOutShortMsg,
+                               midiOutUnprepareHeader};
 
-use ::{MidiMessage, Ignore};
-use ::errors::*;
+use self::winapi::um::mmsystem::{CALLBACK_FUNCTION, CALLBACK_NULL, HMIDIIN, HMIDIOUT, LPMIDIHDR,
+                                 MIDIERR_NOTREADY, MIDIERR_STILLPLAYING, MIDIHDR, MIDIINCAPSW,
+                                 MIDIOUTCAPSW, MMSYSERR_BADDEVICEID, MMSYSERR_NOERROR};
+
+use {Ignore, MidiMessage};
+use errors::*;
 
 mod handler;
 


### PR DESCRIPTION
DO NOT MERGE YET

This is only a test, because winapi 0.3 has not yet been released (it's specified as a git dependency). See retep998/winapi-rs#316.