### PR TITLE
impl Error for ConnectError (the right way)

### DIFF
--- a/examples/test.rs
+++ b/examples/test.rs
@@ -17,47 +17,47 @@ fn main() {
 fn run() -> Result<(), Box<Error>> {
     let mut input = String::new();
     
-    let mut midi_in = try!(MidiInput::new("My Test Input"));
+    let mut midi_in = MidiInput::new("My Test Input")?;
     midi_in.ignore(Ignore::None);
-    let midi_out = try!(MidiOutput::new("My Test Output"));
+    let midi_out = MidiOutput::new("My Test Output")?;
     
     println!("Available input ports:");
     for i in 0..midi_in.port_count() {
         println!("{}: {}", i, midi_in.port_name(i).unwrap());
     }
     print!("Please select input port: ");
-    try!(stdout().flush());
-    try!(stdin().read_line(&mut input));
-    let in_port: usize = try!(input.trim().parse());
+    stdout().flush()?;
+    stdin().read_line(&mut input)?;
+    let in_port: usize = input.trim().parse()?;
     
     println!("\nAvailable output ports:");
     for i in 0..midi_out.port_count() {
         println!("{}: {}", i, midi_out.port_name(i).unwrap());
     }
     print!("Please select output port: ");
-    try!(stdout().flush());
+    stdout().flush()?;
     input.clear();
-    try!(stdin().read_line(&mut input));
-    let out_port: usize = try!(input.trim().parse());
+    stdin().read_line(&mut input)?;
+    let out_port: usize = input.trim().parse()?;
     
     println!("\nOpening connections");
-    let conn_in = try!(midi_in.connect(in_port, "midir-test", |stamp, message, _| {
+    let conn_in = midi_in.connect(in_port, "midir-test", |stamp, message, _| {
         println!("{}: {:?} (len = {})", stamp, message, message.len());
-    }, ()));
+    }, ())?;
     
-    let mut conn_out = try!(midi_out.connect(out_port, "midir-test"));
+    let mut conn_out = midi_out.connect(out_port, "midir-test")?;
     
     println!("Connections open, enter `q` to exit ...");
     
     loop {
         input.clear();
-        try!(stdin().read_line(&mut input));
+        stdin().read_line(&mut input)?;
         if input.trim() == "q" {
             break;
         } else {
-            try!(conn_out.send(&[144, 60, 1]));
+            conn_out.send(&[144, 60, 1])?;
             sleep(Duration::from_millis(200));
-            try!(conn_out.send(&[144, 60, 0]));
+            conn_out.send(&[144, 60, 0])?;
         }
     }
     println!("Closing connections");

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -43,9 +43,9 @@ fn run() -> Result<(), Box<Error>> {
     println!("\nOpening connections");
     let conn_in = try!(midi_in.connect(in_port, "midir-test", |stamp, message, _| {
         println!("{}: {:?} (len = {})", stamp, message, message.len());
-    }, ()).map_err(|e| e.kind()));
+    }, ()));
     
-    let mut conn_out = try!(midi_out.connect(out_port, "midir-test").map_err(|e| e.kind()));
+    let mut conn_out = try!(midi_out.connect(out_port, "midir-test"));
     
     println!("Connections open, enter `q` to exit ...");
     

--- a/examples/test_play.rs
+++ b/examples/test_play.rs
@@ -38,7 +38,7 @@ fn run() -> Result<(), Box<Error>> {
     };
     
     println!("\nOpening connection");
-    let mut conn_out = try!(midi_out.connect(out_port, "midir-test").map_err(|e| e.kind()));
+    let mut conn_out = try!(midi_out.connect(out_port, "midir-test"));
     println!("Connection open. Listen!");
     {
         // Define a new scope in which the closure `play_note` borrows conn_out, so it can be called easily

--- a/examples/test_play.rs
+++ b/examples/test_play.rs
@@ -15,7 +15,7 @@ fn main() {
 }
 
 fn run() -> Result<(), Box<Error>> {
-    let midi_out = try!(MidiOutput::new("My Test Output"));
+    let midi_out = MidiOutput::new("My Test Output")?;
     
     // Get an output port (read from console if multiple are available)
     let out_port = match midi_out.port_count() {
@@ -30,15 +30,15 @@ fn run() -> Result<(), Box<Error>> {
                 println!("{}: {}", i, midi_out.port_name(i).unwrap());
             }
             print!("Please select output port: ");
-            try!(stdout().flush());
+            stdout().flush()?;
             let mut input = String::new();
-            try!(stdin().read_line(&mut input));
-            try!(input.trim().parse())
+            stdin().read_line(&mut input)?;
+            input.trim().parse()?
         }
     };
     
     println!("\nOpening connection");
-    let mut conn_out = try!(midi_out.connect(out_port, "midir-test"));
+    let mut conn_out = midi_out.connect(out_port, "midir-test")?;
     println!("Connection open. Listen!");
     {
         // Define a new scope in which the closure `play_note` borrows conn_out, so it can be called easily

--- a/examples/test_reuse.rs
+++ b/examples/test_reuse.rs
@@ -49,10 +49,10 @@ fn run() -> Result<(), Box<Error>> {
             // The last of the three callback parameters is the object that we pass in as last parameter of `connect`.
             println!("{}: {:?} (len = {})", stamp, message, message.len());
             log.extend_from_slice(message);
-        }, log_all_bytes).map_err(|e| e.kind()));
+        }, log_all_bytes));
         
         // One could get the log back here out of the error
-        let mut conn_out = try!(midi_out.connect(out_port, "midir-test").map_err(|e| e.kind()));
+        let mut conn_out = try!(midi_out.connect(out_port, "midir-test"));
         
         println!("Connections open, enter `q` to exit ...");
         

--- a/examples/test_reuse.rs
+++ b/examples/test_reuse.rs
@@ -17,54 +17,54 @@ fn main() {
 fn run() -> Result<(), Box<Error>> {
     let mut input = String::new();
     
-    let mut midi_in = try!(MidiInput::new("My Test Input"));
+    let mut midi_in = MidiInput::new("My Test Input")?;
     midi_in.ignore(Ignore::None);
-    let mut midi_out = try!(MidiOutput::new("My Test Output"));
+    let mut midi_out = MidiOutput::new("My Test Output")?;
     
     println!("Available input ports:");
     for i in 0..midi_in.port_count() {
         println!("{}: {}", i, midi_in.port_name(i).unwrap());
     }
     print!("Please select input port: ");
-    try!(stdout().flush());
-    try!(stdin().read_line(&mut input));
-    let in_port: usize = try!(input.trim().parse());
+    stdout().flush()?;
+    stdin().read_line(&mut input)?;
+    let in_port: usize = input.trim().parse()?;
     
     println!("\nAvailable output ports:");
     for i in 0..midi_out.port_count() {
         println!("{}: {}", i, midi_out.port_name(i).unwrap());
     }
     print!("Please select output port: ");
-    try!(stdout().flush());
+    stdout().flush()?;
     input.clear();
-    try!(stdin().read_line(&mut input));
-    let out_port: usize = try!(input.trim().parse());
+    stdin().read_line(&mut input)?;
+    let out_port: usize = input.trim().parse()?;
     
     // This shows how to reuse input and output objects:
     // Open/close the connections twice using the same MidiInput/MidiOutput objects
     for _ in 0..2 {
         println!("\nOpening connections");
         let log_all_bytes = Vec::new(); // We use this as an example custom data to pass into the callback
-        let conn_in = try!(midi_in.connect(in_port, "midir-test", |stamp, message, log| {
+        let conn_in = midi_in.connect(in_port, "midir-test", |stamp, message, log| {
             // The last of the three callback parameters is the object that we pass in as last parameter of `connect`.
             println!("{}: {:?} (len = {})", stamp, message, message.len());
             log.extend_from_slice(message);
-        }, log_all_bytes));
+        }, log_all_bytes)?;
         
         // One could get the log back here out of the error
-        let mut conn_out = try!(midi_out.connect(out_port, "midir-test"));
+        let mut conn_out = midi_out.connect(out_port, "midir-test")?;
         
         println!("Connections open, enter `q` to exit ...");
         
         loop {
             input.clear();
-            try!(stdin().read_line(&mut input));
+            stdin().read_line(&mut input)?;
             if input.trim() == "q" {
                 break;
             } else {
-                try!(conn_out.send(&[144, 60, 1]));
+                conn_out.send(&[144, 60, 1])?;
                 sleep(Duration::from_millis(200));
-                try!(conn_out.send(&[144, 60, 0]));
+                conn_out.send(&[144, 60, 0])?;
             }
         }
         println!("Closing connections");

--- a/examples/test_sysex.rs
+++ b/examples/test_sysex.rs
@@ -26,12 +26,12 @@ fn run() -> Result<(), Box<Error>> {
     println!("Creating virtual input port ...");
     let conn_in = try!(midi_in.create_virtual("midir-test", |stamp, message, _| {
         println!("{}: {:?} (len = {})", stamp, message, message.len());
-    }, ()).map_err(|e| e.kind()));
+    }, ()));
     
     assert_eq!(midi_out.port_count(), previous_count + 1);
     
     println!("Connecting to port '{}' ...", midi_out.port_name(previous_count).unwrap());
-    let mut conn_out = try!(midi_out.connect(previous_count, "midir-test").map_err(|e| e.kind()));
+    let mut conn_out = try!(midi_out.connect(previous_count, "midir-test"));
     println!("Starting to send messages ...");
     //sleep(Duration::from_millis(2000));
     println!("Sending NoteOn message");

--- a/examples/test_sysex.rs
+++ b/examples/test_sysex.rs
@@ -17,28 +17,28 @@ fn main() {
 const LARGE_SYSEX_SIZE: usize = 5572; // This is the maximum that worked for me
 
 fn run() -> Result<(), Box<Error>> {
-    let mut midi_in = try!(MidiInput::new("My Test Input"));
+    let mut midi_in = MidiInput::new("My Test Input")?;
     midi_in.ignore(Ignore::None);
-    let midi_out = try!(MidiOutput::new("My Test Output"));
+    let midi_out = MidiOutput::new("My Test Output")?;
     
     let previous_count = midi_out.port_count();
     
     println!("Creating virtual input port ...");
-    let conn_in = try!(midi_in.create_virtual("midir-test", |stamp, message, _| {
+    let conn_in = midi_in.create_virtual("midir-test", |stamp, message, _| {
         println!("{}: {:?} (len = {})", stamp, message, message.len());
-    }, ()));
+    }, ())?;
     
     assert_eq!(midi_out.port_count(), previous_count + 1);
     
     println!("Connecting to port '{}' ...", midi_out.port_name(previous_count).unwrap());
-    let mut conn_out = try!(midi_out.connect(previous_count, "midir-test"));
+    let mut conn_out = midi_out.connect(previous_count, "midir-test")?;
     println!("Starting to send messages ...");
     //sleep(Duration::from_millis(2000));
     println!("Sending NoteOn message");
-    try!(conn_out.send(&[144, 60, 1]));
+    conn_out.send(&[144, 60, 1])?;
     sleep(Duration::from_millis(200));
     println!("Sending small SysEx message ...");
-    try!(conn_out.send(&[0xF0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xF7]));
+    conn_out.send(&[0xF0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xF7])?;
     sleep(Duration::from_millis(200));
     println!("Sending large SysEx message ...");
     let mut v = Vec::with_capacity(LARGE_SYSEX_SIZE);
@@ -48,15 +48,15 @@ fn run() -> Result<(), Box<Error>> {
     }
     v.push(0xF7u8);
     assert_eq!(v.len(), LARGE_SYSEX_SIZE);
-    try!(conn_out.send(&v));
+    conn_out.send(&v)?;
     sleep(Duration::from_millis(200));
     println!("Sending large SysEx message (chunked)...");
     for ch in v.chunks(4) {
-        try!(conn_out.send(ch));
+        conn_out.send(ch)?;
     }
     sleep(Duration::from_millis(200));
     println!("Sending small SysEx message ...");
-    try!(conn_out.send(&[0xF0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xF7]));
+    conn_out.send(&[0xF0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xF7])?;
     sleep(Duration::from_millis(200));
     println!("Closing output ...");
     conn_out.close();

--- a/examples/test_virtual.rs
+++ b/examples/test_virtual.rs
@@ -15,25 +15,25 @@ fn main() {
 }
 
 fn run() -> Result<(), Box<Error>> {
-    let mut midi_in = try!(MidiInput::new("My Test Input"));
+    let mut midi_in = MidiInput::new("My Test Input")?;
     midi_in.ignore(Ignore::None);
-    let midi_out = try!(MidiOutput::new("My Test Output"));
+    let midi_out = MidiOutput::new("My Test Output")?;
     
     let previous_count = midi_out.port_count();
     
     println!("Creating virtual input port ...");
-    let conn_in = try!(midi_in.create_virtual("midir-test", |stamp, message, _| {
+    let conn_in = midi_in.create_virtual("midir-test", |stamp, message, _| {
         println!("{}: {:?} (len = {})", stamp, message, message.len());
-    }, ()));
+    }, ())?;
     
     assert_eq!(midi_out.port_count(), previous_count + 1);
     
     println!("Connecting to port '{}' ...", midi_out.port_name(previous_count).unwrap());
-    let mut conn_out = try!(midi_out.connect(previous_count, "midir-test"));
+    let mut conn_out = midi_out.connect(previous_count, "midir-test")?;
     println!("Starting to send messages ...");
-    try!(conn_out.send(&[144, 60, 1]));
+    conn_out.send(&[144, 60, 1])?;
     sleep(Duration::from_millis(200));
-    try!(conn_out.send(&[144, 60, 0]));
+    conn_out.send(&[144, 60, 0])?;
     sleep(Duration::from_millis(200));
     println!("Closing output ...");
     let midi_out = conn_out.close();
@@ -44,17 +44,17 @@ fn run() -> Result<(), Box<Error>> {
     let previous_count = midi_in.port_count();
     
     println!("\nCreating virtual output port ...");
-    let mut conn_out = try!(midi_out.create_virtual("midir-test"));
+    let mut conn_out = midi_out.create_virtual("midir-test")?;
     assert_eq!(midi_in.port_count(), previous_count + 1);
     
     println!("Connecting to port '{}' ...", midi_in.port_name(previous_count).unwrap());
-    let conn_in = try!(midi_in.connect(previous_count, "midir-test", |stamp, message, _| {
+    let conn_in = midi_in.connect(previous_count, "midir-test", |stamp, message, _| {
         println!("{}: {:?} (len = {})", stamp, message, message.len());
-    }, ()));
+    }, ())?;
     println!("Starting to send messages ...");
-    try!(conn_out.send(&[144, 60, 1]));
+    conn_out.send(&[144, 60, 1])?;
     sleep(Duration::from_millis(200));
-    try!(conn_out.send(&[144, 60, 0]));
+    conn_out.send(&[144, 60, 0])?;
     sleep(Duration::from_millis(200));
     println!("Closing input ...");
     let midi_in = conn_in.close().0;

--- a/examples/test_virtual.rs
+++ b/examples/test_virtual.rs
@@ -24,12 +24,12 @@ fn run() -> Result<(), Box<Error>> {
     println!("Creating virtual input port ...");
     let conn_in = try!(midi_in.create_virtual("midir-test", |stamp, message, _| {
         println!("{}: {:?} (len = {})", stamp, message, message.len());
-    }, ()).map_err(|e| e.kind()));
+    }, ()));
     
     assert_eq!(midi_out.port_count(), previous_count + 1);
     
     println!("Connecting to port '{}' ...", midi_out.port_name(previous_count).unwrap());
-    let mut conn_out = try!(midi_out.connect(previous_count, "midir-test").map_err(|e| e.kind()));
+    let mut conn_out = try!(midi_out.connect(previous_count, "midir-test"));
     println!("Starting to send messages ...");
     try!(conn_out.send(&[144, 60, 1]));
     sleep(Duration::from_millis(200));
@@ -44,13 +44,13 @@ fn run() -> Result<(), Box<Error>> {
     let previous_count = midi_in.port_count();
     
     println!("\nCreating virtual output port ...");
-    let mut conn_out = try!(midi_out.create_virtual("midir-test").map_err(|e| e.kind()));
+    let mut conn_out = try!(midi_out.create_virtual("midir-test"));
     assert_eq!(midi_in.port_count(), previous_count + 1);
     
     println!("Connecting to port '{}' ...", midi_in.port_name(previous_count).unwrap());
     let conn_in = try!(midi_in.connect(previous_count, "midir-test", |stamp, message, _| {
         println!("{}: {:?} (len = {})", stamp, message, message.len());
-    }, ()).map_err(|e| e.kind()));
+    }, ()));
     println!("Starting to send messages ...");
     try!(conn_out.send(&[144, 60, 1]));
     sleep(Duration::from_millis(200));

--- a/src/backend/alsa/mod.rs
+++ b/src/backend/alsa/mod.rs
@@ -45,10 +45,10 @@ mod helpers {
             None => return Err(PortInfoError::PortNumberOutOfRange)
         };
 
-        let cinfo = try!(s.get_any_client_info(pinfo.get_client()).map_err(|_| PortInfoError::CannotRetrievePortName));
+        let cinfo = s.get_any_client_info(pinfo.get_client()).map_err(|_| PortInfoError::CannotRetrievePortName)?;
         let mut output = String::new();
         write!(&mut output, "{} {}:{}", 
-            try!(cinfo.get_name().map_err(|_| PortInfoError::CannotRetrievePortName)),
+            cinfo.get_name().map_err(|_| PortInfoError::CannotRetrievePortName)?,
             pinfo.get_client(), // These lines added to make sure devices are listed
             pinfo.get_port()    // with full portnames added to ensure individual device names
         ).unwrap();
@@ -138,8 +138,8 @@ impl MidiInput {
             Err(_) => { return Err(InitError); }
         };
         
-        let c_client_name = try!(CString::new(client_name).map_err(|_| InitError));
-        try!(seq.set_client_name(&c_client_name).map_err(|_| InitError));
+        let c_client_name = CString::new(client_name).map_err(|_| InitError)?;
+        seq.set_client_name(&c_client_name).map_err(|_| InitError)?;
         
         Ok(MidiInput {
             ignore_flags: Ignore::None,
@@ -418,8 +418,8 @@ impl MidiOutput {
             Err(_) => { return Err(InitError); }
         };
         
-        let c_client_name = try!(CString::new(client_name).map_err(|_| InitError));
-        try!(seq.set_client_name(&c_client_name).map_err(|_| InitError));
+        let c_client_name = CString::new(client_name).map_err(|_| InitError)?;
+        seq.set_client_name(&c_client_name).map_err(|_| InitError)?;
         
         Ok(MidiOutput {
             seq: Some(seq),

--- a/src/backend/coremidi/mod.rs
+++ b/src/backend/coremidi/mod.rs
@@ -38,7 +38,7 @@ impl MidiInput {
     }
     
     pub fn port_name(&self, port_number: usize) -> Result<String, PortInfoError> {
-        let endpoint = try!(Source::from_index(port_number).ok_or(PortInfoError::PortNumberOutOfRange));
+        let endpoint = Source::from_index(port_number).ok_or(PortInfoError::PortNumberOutOfRange)?;
         match endpoint.display_name() {
             Some(name) => Ok(name),
             None => Err(PortInfoError::CannotRetrievePortName)
@@ -263,7 +263,7 @@ impl MidiOutput {
     }
     
     pub fn port_name(&self, port_number: usize) -> Result<String, PortInfoError> {
-        let endpoint = try!(Destination::from_index(port_number).ok_or(PortInfoError::PortNumberOutOfRange));
+        let endpoint = Destination::from_index(port_number).ok_or(PortInfoError::PortNumberOutOfRange)?;
         match endpoint.display_name() {
             Some(name) => Ok(name),
             None => Err(PortInfoError::CannotRetrievePortName)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -51,7 +51,7 @@ pub enum ConnectErrorKind {
     Other(&'static str)
 }
 
-impl Error for ConnectErrorKind {
+impl ConnectErrorKind {
     fn description(&self) -> &str {
         match *self {
             ConnectErrorKind::PortNumberOutOfRange => PORT_OUT_OF_RANGE_MSG,
@@ -103,10 +103,11 @@ impl<T> fmt::Display for ConnectError<T> {
     }
 }
 
-// This is currently not possible in stable Rust, but instead we can directly
-// implement a conversion to Box<Error> by boxing just the error kind.
-
-//impl<T: Reflect> Error for ConnectError<T>
+impl<T> Error for ConnectError<T> {
+    fn description(&self) -> &str {
+        self.kind.description()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// An error that can occur when sending MIDI messages.


### PR DESCRIPTION
Implement the `Error` trait correctly for `ConnectError`, as it should have been done from the beginning (but wasn't possible for some reason).

This is a breaking change, because `ConnectErrorKind` does not impl `Error` any more!

Also change all occurences of `try!` to use `?` instead, which makes the examples a bit nicer.