### PR TITLE
Per-platform unique port identifiers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bitflags = "0.3"
 memalloc = "0.1.0"
 jack-sys = { version = "0.1.0", optional = true }
 libc = { version = "0.2.21", optional = true }
-winrt = { version = "0.4.0", features = ["windows-devices", "windows-storage"], optional = true}
+winrt = { version = "0.5.0", features = ["windows-devices", "windows-storage"], optional = true}
 
 [target.'cfg(target_os = "linux")'.dependencies]
 alsa = "0.2"

--- a/examples/test_forward.rs
+++ b/examples/test_forward.rs
@@ -20,23 +20,27 @@ fn run() -> Result<(), Box<Error>> {
     let midi_out = MidiOutput::new("midir forwarding output")?;
     
     println!("Available input ports:");
-    for i in 0..midi_in.port_count() {
-        println!("{}: {}", i, midi_in.port_name(i)?);
+    let midi_in_ports = midi_in.ports();
+    for (i, p) in midi_in_ports.iter().enumerate() {
+        println!("{}: {}", i, midi_in.port_name(p)?);
     }
     print!("Please select input port: ");
     stdout().flush()?;
     stdin().read_line(&mut input)?;
-    let in_port: usize = input.trim().parse()?;
+    let in_port = midi_in_ports.get(input.trim().parse::<usize>()?)
+                               .ok_or("Invalid port number")?;
     
     println!("\nAvailable output ports:");
-    for i in 0..midi_out.port_count() {
-        println!("{}: {}", i, midi_out.port_name(i)?);
+    let midi_out_ports = midi_out.ports();
+    for (i, p) in midi_out_ports.iter().enumerate() {
+        println!("{}: {}", i, midi_out.port_name(p)?);
     }
     print!("Please select output port: ");
     stdout().flush()?;
     input.clear();
     stdin().read_line(&mut input)?;
-    let out_port: usize = input.trim().parse()?;
+    let out_port = midi_out_ports.get(input.trim().parse::<usize>()?)
+                                 .ok_or("Invalid port number")?;
     
     println!("\nOpening connections");
     let in_port_name = midi_in.port_name(in_port)?;

--- a/examples/test_list_ports.rs
+++ b/examples/test_list_ports.rs
@@ -21,13 +21,13 @@ fn run() -> Result<(), Box<Error>> {
 
     loop {
         println!("Available input ports:");
-        for i in 0..midi_in.port_count() {
-            println!("{}: {}", i, midi_in.port_name(i)?);
+        for (i, p) in midi_in.ports().iter().enumerate() {
+            println!("{}: {}", i, midi_in.port_name(p)?);
         }
         
         println!("\nAvailable output ports:");
-        for i in 0..midi_out.port_count() {
-            println!("{}: {}", i, midi_out.port_name(i)?);
+        for (i, p) in midi_out.ports().iter().enumerate() {
+            println!("{}: {}", i, midi_out.port_name(p)?);
         }
 
         // run in endless loop if "--loop" parameter is specified

--- a/examples/test_read_input.rs
+++ b/examples/test_read_input.rs
@@ -19,22 +19,24 @@ fn run() -> Result<(), Box<Error>> {
     midi_in.ignore(Ignore::None);
     
     // Get an input port (read from console if multiple are available)
-    let in_port = match midi_in.port_count() {
+    let in_ports = midi_in.ports();
+    let in_port = match in_ports.len() {
         0 => return Err("no input port found".into()),
         1 => {
-            println!("Choosing the only available input port: {}", midi_in.port_name(0).unwrap());
-            0
+            println!("Choosing the only available input port: {}", midi_in.port_name(&in_ports[0]).unwrap());
+            &in_ports[0]
         },
         _ => {
             println!("\nAvailable input ports:");
-            for i in 0..midi_in.port_count() {
-                println!("{}: {}", i, midi_in.port_name(i).unwrap());
+            for (i, p) in in_ports.iter().enumerate() {
+                println!("{}: {}", i, midi_in.port_name(p).unwrap());
             }
             print!("Please select input port: ");
             stdout().flush()?;
             let mut input = String::new();
             stdin().read_line(&mut input)?;
-            input.trim().parse()?
+            in_ports.get(input.trim().parse::<usize>()?)
+                     .ok_or("invalid input port selected")?
         }
     };
     

--- a/examples/test_reuse.rs
+++ b/examples/test_reuse.rs
@@ -22,23 +22,27 @@ fn run() -> Result<(), Box<Error>> {
     let mut midi_out = MidiOutput::new("My Test Output")?;
     
     println!("Available input ports:");
-    for i in 0..midi_in.port_count() {
-        println!("{}: {}", i, midi_in.port_name(i).unwrap());
+    let midi_in_ports = midi_in.ports();
+    for (i, p) in midi_in_ports.iter().enumerate() {
+        println!("{}: {}", i, midi_in.port_name(p)?);
     }
     print!("Please select input port: ");
     stdout().flush()?;
     stdin().read_line(&mut input)?;
-    let in_port: usize = input.trim().parse()?;
+    let in_port = midi_in_ports.get(input.trim().parse::<usize>()?)
+                               .ok_or("Invalid port number")?;
     
     println!("\nAvailable output ports:");
-    for i in 0..midi_out.port_count() {
-        println!("{}: {}", i, midi_out.port_name(i).unwrap());
+    let midi_out_ports = midi_out.ports();
+    for (i, p) in midi_out_ports.iter().enumerate() {
+        println!("{}: {}", i, midi_out.port_name(p)?);
     }
     print!("Please select output port: ");
     stdout().flush()?;
     input.clear();
     stdin().read_line(&mut input)?;
-    let out_port: usize = input.trim().parse()?;
+    let out_port = midi_out_ports.get(input.trim().parse::<usize>()?)
+                                 .ok_or("Invalid port number")?;
     
     // This shows how to reuse input and output objects:
     // Open/close the connections twice using the same MidiInput/MidiOutput objects

--- a/examples/test_sysex.rs
+++ b/examples/test_sysex.rs
@@ -33,8 +33,10 @@ pub fn run() -> Result<(), Box<Error>> {
     
     assert_eq!(midi_out.port_count(), previous_count + 1);
     
-    println!("Connecting to port '{}' ...", midi_out.port_name(previous_count).unwrap());
-    let mut conn_out = midi_out.connect(previous_count, "midir-test")?;
+    let out_ports = midi_out.ports();
+    let new_port = out_ports.last().unwrap();
+    println!("Connecting to port '{}' ...", midi_out.port_name(&new_port).unwrap());
+    let mut conn_out = midi_out.connect(&new_port, "midir-test")?;
     println!("Starting to send messages ...");
     //sleep(Duration::from_millis(2000));
     println!("Sending NoteOn message");
@@ -53,6 +55,7 @@ pub fn run() -> Result<(), Box<Error>> {
     assert_eq!(v.len(), LARGE_SYSEX_SIZE);
     conn_out.send(&v)?;
     sleep(Duration::from_millis(200));
+    // FIXME: the following doesn't seem to work with ALSA
     println!("Sending large SysEx message (chunked)...");
     for ch in v.chunks(4) {
         conn_out.send(ch)?;

--- a/src/backend/jack/wrappers.rs
+++ b/src/backend/jack/wrappers.rs
@@ -128,8 +128,13 @@ impl Client {
         unsafe { jack_set_process_callback(self.p, Some(callback), data) };
     }
     
-    pub fn connect(&mut self, source_port: &CStr, destination_port: &CStr) {
-        unsafe { jack_connect(self.p, source_port.as_ptr(), destination_port.as_ptr()) };
+    pub fn connect(&mut self, source_port: &CStr, destination_port: &CStr) -> Result<(), ()> {
+        let rc = unsafe { jack_connect(self.p, source_port.as_ptr(), destination_port.as_ptr()) };
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(()) // TODO: maybe handle EEXIST explicitly
+        }
     }
 }
 

--- a/src/backend/winmm/handler.rs
+++ b/src/backend/winmm/handler.rs
@@ -65,10 +65,10 @@ pub extern "system" fn handle_input<T>(_: HMIDIIN,
         // buffer when an application closes and in this case, we should
         // avoid requeueing it, else the computer suddenly reboots after
         // one or two minutes.
-        if (unsafe {*data.sysex_buffer[sysex.dwUser as usize]}).dwBytesRecorded > 0 {
+        if (unsafe {*data.sysex_buffer.0[sysex.dwUser as usize]}).dwBytesRecorded > 0 {
         //if ( sysex->dwBytesRecorded > 0 ) {
-            let in_handle = data.in_handle.as_ref().unwrap().lock().unwrap();
-            let result = unsafe { midiInAddBuffer(*in_handle, data.sysex_buffer[sysex.dwUser as usize], mem::size_of::<MIDIHDR>() as u32) };
+            let in_handle = data.in_handle.as_ref().unwrap().0.lock().unwrap();
+            let result = unsafe { midiInAddBuffer(*in_handle, data.sysex_buffer.0[sysex.dwUser as usize], mem::size_of::<MIDIHDR>() as u32) };
             drop(in_handle);
             if result != MMSYSERR_NOERROR {
                 let _ = writeln!(stderr(), "\nError in handle_input: Requeuing WinMM input sysex buffer failed.\n");

--- a/src/backend/winrt/mod.rs
+++ b/src/backend/winrt/mod.rs
@@ -11,11 +11,19 @@ use self::winrt::windows::storage::streams::*;
 use ::errors::*;
 use ::Ignore;
 
+pub struct MidiInputPort {
+    id: HString
+}
+
+unsafe impl Send for MidiInputPort {} // because HString doesn't ...
+
 pub struct MidiInput {
     rt: RuntimeContext,
     selector: HString,
     ignore_flags: Ignore
 }
+
+unsafe impl Send for MidiInput {} // because HString doesn't ...
 
 impl MidiInput {
     pub fn new(_client_name: &str) -> Result<Self, InitError> {
@@ -27,19 +35,30 @@ impl MidiInput {
     pub fn ignore(&mut self, flags: Ignore) {
         self.ignore_flags = flags;
     }
-    
-    pub fn port_count(&self) -> usize {
-        let device_collection = DeviceInformation::find_all_async_aqs_filter(&self.selector.make_reference()).unwrap().blocking_get().expect("find_all_async failed");
-        unsafe { device_collection.get_size().expect("get_size failed") as usize }
+
+    pub(crate) fn ports_internal(&self) -> Vec<::common::MidiInputPort> {
+        let device_collection = DeviceInformation::find_all_async_aqs_filter(&self.selector.make_reference()).unwrap().blocking_get().expect("find_all_async failed").expect("find_all_async returned null");
+        let count = device_collection.get_size().expect("get_size failed") as usize;
+        let mut result = Vec::with_capacity(count as usize);
+        for device_info in device_collection.into_iter() {
+            let device_info = device_info.expect("device_info was null");
+            let device_id = device_info.get_id().expect("get_id failed");
+            result.push(::common::MidiInputPort {
+                imp: MidiInputPort { id: device_id }
+            });
+        }
+        result
     }
     
-    pub fn port_name(&self, port_number: usize) -> Result<String, PortInfoError> {
-        let device_collection = DeviceInformation::find_all_async_aqs_filter(&self.selector.make_reference()).unwrap().blocking_get().expect("find_all_async failed");
-        let device_name;
-        unsafe {
-            let device_info = device_collection.get_at(port_number as u32).map_err(|_| PortInfoError::PortNumberOutOfRange)?;
-            device_name = device_info.get_name().map_err(|_| PortInfoError::CannotRetrievePortName)?;
-        }
+    pub fn port_count(&self) -> usize {
+        let device_collection = DeviceInformation::find_all_async_aqs_filter(&self.selector.make_reference()).unwrap().blocking_get().expect("find_all_async failed").expect("find_all_async returned null");
+        device_collection.get_size().expect("get_size failed") as usize
+    }
+    
+    pub fn port_name(&self, port: &MidiInputPort) -> Result<String, PortInfoError> {
+        let device_info_async = DeviceInformation::create_from_id_async(&port.id.make_reference()).map_err(|_| PortInfoError::InvalidPort)?;
+        let device_info = device_info_async.blocking_get().map_err(|_| PortInfoError::InvalidPort)?.expect("device_info was null");
+        let device_name = device_info.get_name().map_err(|_| PortInfoError::CannotRetrievePortName)?;
         Ok(device_name.to_string())
     }
 
@@ -50,11 +69,11 @@ impl MidiInput {
         let byte_access;
         let message_bytes;
         unsafe {
-            let message = args.get_message().expect("get_message failed");
+            let message = args.get_message().expect("get_message failed").expect("get_message returned null");
             timestamp = message.get_timestamp().expect("get_timestamp failed").Duration as u64 / 10;
-            let buffer = message.get_raw_data().expect("get_raw_data failed");
-            let membuffer = Buffer::create_memory_buffer_over_ibuffer(&buffer).expect("create_memory_buffer_over_ibuffer failed");
-            byte_access = membuffer.create_reference().expect("create_reference failed").query_interface::<IMemoryBufferByteAccess>().unwrap();
+            let buffer = message.get_raw_data().expect("get_raw_data failed").expect("get_raw_data returned null");
+            let membuffer = Buffer::create_memory_buffer_over_ibuffer(&buffer).expect("create_memory_buffer_over_ibuffer failed").expect("create_memory_buffer_over_ibuffer returned null");
+            byte_access = membuffer.create_reference().expect("create_reference failed").expect("create_reference returned null").query_interface::<IMemoryBufferByteAccess>().unwrap();
             message_bytes = byte_access.get_buffer();
         }
 
@@ -71,49 +90,42 @@ impl MidiInput {
     }
 
     pub fn connect<F, T: Send + 'static>(
-        self, port_number: usize, _port_name: &str, callback: F, data: T
+        self, port: &MidiInputPort, _port_name: &str, callback: F, data: T
     ) -> Result<MidiInputConnection<T>, ConnectError<MidiInput>>
         where F: FnMut(u64, &[u8], &mut T) + Send + 'static {
+        
+        let in_port = match MidiInPort::from_id_async(&port.id.make_reference()) {
+            Ok(port_async) => match port_async.blocking_get() {
+                Ok(Some(port)) => port,
+                _ => return Err(ConnectError::new(ConnectErrorKind::InvalidPort, self))
+            }
+            Err(_) => return Err(ConnectError::new(ConnectErrorKind::InvalidPort, self))
+        };
+        
+        let handler_data = Arc::new(Mutex::new(HandlerData {
+            ignore_flags: self.ignore_flags,
+            callback: Box::new(callback),
+            user_data: Some(data)
+        }));
+        let handler_data2 = handler_data.clone();
 
-        let device_collection = DeviceInformation::find_all_async_aqs_filter(&self.selector.make_reference()).unwrap().blocking_get().expect("find_all_async failed");
-        unsafe {
-            let device_info = match device_collection.get_at(port_number as u32) {
-                Ok(info) => info,
-                Err(_) => return Err(ConnectError::new(ConnectErrorKind::PortNumberOutOfRange, self))
-            };
-            let device_id = match device_info.get_id() {
-                Ok(id) => id,
-                Err(_) => return Err(ConnectError::other("get_id failed", self))
-            };
-            let in_port = match MidiInPort::from_id_async(&device_id.make_reference()) {
-                Ok(port_async) => match port_async.blocking_get() {
-                    Ok(port) => port,
-                    Err(_) => return Err(ConnectError::other("getting result from MidiInPort::from_id_async failed", self))
-                }
-                Err(_) => return Err(ConnectError::other("MidiInPort::from_id_async failed", self))
-            };
+        let handler = TypedEventHandler::new(move |_sender, args: *mut MidiMessageReceivedEventArgs| {
+            unsafe { MidiInput::handle_input(&*args, &mut *handler_data2.lock().unwrap()) };
+            Ok(())
+        });
+        
+        let event_token = in_port.add_message_received(&handler).expect("add_message_received failed");
 
-            let handler_data = Arc::new(Mutex::new(HandlerData {
-                ignore_flags: self.ignore_flags,
-                callback: Box::new(callback),
-                user_data: Some(data)
-            }));
-            let handler_data2 = handler_data.clone();
-
-            let handler = TypedEventHandler::new(move |_sender, args: *mut MidiMessageReceivedEventArgs| {
-                MidiInput::handle_input(&*args, &mut *handler_data2.lock().unwrap());
-                Ok(())
-            });
-            let event_token = in_port.add_message_received(&handler).expect("add_message_received failed");
-
-            Ok(MidiInputConnection { rt: self.rt, port: in_port, event_token: event_token, handler_data: handler_data })
-        }
+        Ok(MidiInputConnection { rt: self.rt, port: RtMidiInPort(in_port), event_token: event_token, handler_data: handler_data })
     }
 }
 
+struct RtMidiInPort(ComPtr<MidiInPort>);
+unsafe impl Send for RtMidiInPort {}
+
 pub struct MidiInputConnection<T> {
     rt: RuntimeContext,
-    port: ComPtr<MidiInPort>,
+    port: RtMidiInPort,
     event_token: EventRegistrationToken,
     // TODO: get rid of Arc & Mutex?
     //       synchronization is required because the borrow checker does not
@@ -122,10 +134,11 @@ pub struct MidiInputConnection<T> {
     handler_data: Arc<Mutex<HandlerData<T>>>
 }
 
+
 impl<T> MidiInputConnection<T> {
     pub fn close(self) -> (MidiInput, T) {
-        let _ = unsafe { self.port.remove_message_received(self.event_token) };
-        let _ = unsafe { self.port.query_interface::<IClosable>().unwrap().close() };
+        let _ = self.port.0.remove_message_received(self.event_token);
+        let _ = self.port.0.query_interface::<IClosable>().unwrap().close();
         let device_selector = MidiInPort::get_device_selector().expect("get_device_selector failed"); // probably won't ever fail here, because it worked previously
         let mut handler_data_locked = self.handler_data.lock().unwrap();
         (MidiInput {
@@ -147,10 +160,18 @@ struct HandlerData<T> {
     user_data: Option<T>
 }
 
+pub struct MidiOutputPort {
+    id: HString
+}
+
+unsafe impl Send for MidiOutputPort {} // because HString doesn't ...
+
 pub struct MidiOutput {
     rt: RuntimeContext,
     selector: HString // TODO: change to FastHString?
 }
+
+unsafe impl Send for MidiOutput {} // because HString doesn't ...
 
 impl MidiOutput {
     pub fn new(_client_name: &str) -> Result<Self, InitError> {
@@ -158,42 +179,42 @@ impl MidiOutput {
         let device_selector = MidiOutPort::get_device_selector().map_err(|_| InitError)?;
         Ok(MidiOutput { rt: rt, selector: device_selector })
     }
-    
-    pub fn port_count(&self) -> usize {
-        let device_collection = DeviceInformation::find_all_async_aqs_filter(&self.selector.make_reference()).unwrap().blocking_get().expect("find_all_async failed");
-        unsafe { device_collection.get_size().expect("get_size failed") as usize }
+
+    pub(crate) fn ports_internal(&self) -> Vec<::common::MidiOutputPort> {
+        let device_collection = DeviceInformation::find_all_async_aqs_filter(&self.selector.make_reference()).unwrap().blocking_get().expect("find_all_async failed").expect("find_all_async returned null");
+        let count = device_collection.get_size().expect("get_size failed") as usize;
+        let mut result = Vec::with_capacity(count as usize);
+        for device_info in device_collection.into_iter() {
+            let device_info = device_info.expect("device_info was null");
+            let device_id = device_info.get_id().expect("get_id failed");
+            result.push(::common::MidiOutputPort {
+                imp: MidiOutputPort { id: device_id }
+            });
+        }
+        result
     }
     
-    pub fn port_name(&self, port_number: usize) -> Result<String, PortInfoError> {
-        let device_collection = DeviceInformation::find_all_async_aqs_filter(&self.selector.make_reference()).unwrap().blocking_get().expect("find_all_async failed");
-        let device_name;
-        unsafe {
-            let device_info = device_collection.get_at(port_number as u32).map_err(|_| PortInfoError::PortNumberOutOfRange)?;
-            device_name = device_info.get_name().map_err(|_| PortInfoError::CannotRetrievePortName)?;
-        }
+    pub fn port_count(&self) -> usize {
+        let device_collection = DeviceInformation::find_all_async_aqs_filter(&self.selector.make_reference()).unwrap().blocking_get().expect("find_all_async failed").expect("find_all_async returned null");
+        device_collection.get_size().expect("get_size failed") as usize
+    }
+    
+    pub fn port_name(&self, port: &MidiOutputPort) -> Result<String, PortInfoError> {
+        let device_info_async = DeviceInformation::create_from_id_async(&port.id.make_reference()).map_err(|_| PortInfoError::InvalidPort)?;
+        let device_info = device_info_async.blocking_get().map_err(|_| PortInfoError::InvalidPort)?.expect("device_info_async was null");
+        let device_name = device_info.get_name().map_err(|_| PortInfoError::CannotRetrievePortName)?;
         Ok(device_name.to_string())
     }
     
-    pub fn connect(self, port_number: usize, _port_name: &str) -> Result<MidiOutputConnection, ConnectError<MidiOutput>> {
-        let device_collection = DeviceInformation::find_all_async_aqs_filter(&self.selector.make_reference()).unwrap().blocking_get().expect("find_all_async failed");
-        unsafe {
-            let device_info = match device_collection.get_at(port_number as u32) {
-                Ok(info) => info,
-                Err(_) => return Err(ConnectError::new(ConnectErrorKind::PortNumberOutOfRange, self))
-            };
-            let device_id = match device_info.get_id() {
-                Ok(id) => id,
-                Err(_) => return Err(ConnectError::other("get_id failed", self))
-            };
-            let out_port = match MidiOutPort::from_id_async(&device_id.make_reference()) {
-                Ok(port_async) => match port_async.blocking_get() {
-                    Ok(port) => port,
-                    Err(_) => return Err(ConnectError::other("getting result from MidiOutPort::from_id_async failed", self))
-                }
-                Err(_) => return Err(ConnectError::other("MidiOutPort::from_id_async failed", self))
-            };
-            Ok(MidiOutputConnection { rt: self.rt, port: out_port })
-        }
+    pub fn connect(self, port: &MidiOutputPort, _port_name: &str) -> Result<MidiOutputConnection, ConnectError<MidiOutput>> {        
+        let out_port = match MidiOutPort::from_id_async(&port.id.make_reference()) {
+            Ok(port_async) => match port_async.blocking_get() {
+                Ok(Some(port)) => port,
+                _ => return Err(ConnectError::new(ConnectErrorKind::InvalidPort, self))
+            }
+            Err(_) => return Err(ConnectError::new(ConnectErrorKind::InvalidPort, self))
+        };
+        Ok(MidiOutputConnection { rt: self.rt, port: out_port })
     }
 }
 
@@ -206,18 +227,16 @@ unsafe impl Send for MidiOutputConnection {}
 
 impl MidiOutputConnection {
     pub fn close(self) -> MidiOutput {
-        let _ = unsafe { self.port.query_interface::<IClosable>().unwrap().close() };
+        let _ = self.port.query_interface::<IClosable>().unwrap().close();
         let device_selector = MidiOutPort::get_device_selector().expect("get_device_selector failed"); // probably won't ever fail here, because it worked previously
         MidiOutput { rt: self.rt, selector: device_selector }
     }
     
     pub fn send(&mut self, message: &[u8]) -> Result<(), SendError> {
         let data_writer: ComPtr<DataWriter> = DataWriter::new();
-        unsafe {
-            data_writer.write_bytes(message).map_err(|_| SendError::Other("write_bytes failed"))?;
-            let buffer = data_writer.detach_buffer().map_err(|_| SendError::Other("detach_buffer failed"))?;
-            self.port.send_buffer(&buffer).map_err(|_| SendError::Other("send_buffer failed"))?;
-        }
+        data_writer.write_bytes(message).map_err(|_| SendError::Other("write_bytes failed"))?;
+        let buffer = data_writer.detach_buffer().map_err(|_| SendError::Other("detach_buffer failed"))?.expect("detach buffer returned null");
+        self.port.send_buffer(&buffer).map_err(|_| SendError::Other("send_buffer failed"))?;
         Ok(())
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 use std::fmt;
 
+const INVALID_PORT_MSG: &'static str = "invalid port";
 const PORT_OUT_OF_RANGE_MSG: &'static str = "provided port number was out of range";
 const CANNOT_RETRIEVE_PORT_NAME_MSG: &'static str = "unknown error when trying to retrieve the port name";
 
@@ -25,7 +26,8 @@ impl fmt::Display for InitError {
 /// An error that can occur when retrieving information about
 /// available ports.
 pub enum PortInfoError {
-    PortNumberOutOfRange,
+    PortNumberOutOfRange, // TODO: don't expose this
+    InvalidPort,
     CannotRetrievePortName,
 }
 
@@ -33,6 +35,7 @@ impl Error for PortInfoError {
     fn description(&self) -> &str {
         match *self {
             PortInfoError::PortNumberOutOfRange => PORT_OUT_OF_RANGE_MSG,
+            PortInfoError::InvalidPort => INVALID_PORT_MSG,
             PortInfoError::CannotRetrievePortName => CANNOT_RETRIEVE_PORT_NAME_MSG,
         }
     }
@@ -47,14 +50,14 @@ impl fmt::Display for PortInfoError {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// The kind of error for a `ConnectError`.
 pub enum ConnectErrorKind {
-    PortNumberOutOfRange,
+    InvalidPort,
     Other(&'static str)
 }
 
 impl ConnectErrorKind {
     fn description(&self) -> &str {
         match *self {
-            ConnectErrorKind::PortNumberOutOfRange => PORT_OUT_OF_RANGE_MSG,
+            ConnectErrorKind::InvalidPort => INVALID_PORT_MSG,
             ConnectErrorKind::Other(msg) => msg
         }
     }

--- a/tests/virtual.rs
+++ b/tests/virtual.rs
@@ -5,7 +5,7 @@ extern crate midir;
 use std::thread::sleep;
 use std::time::Duration;
 
-use midir::{MidiInput, MidiOutput, Ignore};
+use midir::{MidiInput, MidiOutput, Ignore, MidiOutputPort};
 use midir::os::unix::{VirtualInput, VirtualOutput};
 
 #[test]
@@ -22,9 +22,11 @@ fn end_to_end() {
     }, ()).unwrap();
     
     assert_eq!(midi_out.port_count(), previous_count + 1);
-    
-    println!("Connecting to port '{}' ...", midi_out.port_name(previous_count).unwrap());
-    let mut conn_out = midi_out.connect(previous_count, "midir-test").unwrap();
+
+    let new_port: MidiOutputPort = midi_out.ports().into_iter().rev().next().unwrap();
+
+    println!("Connecting to port '{}' ...", midi_out.port_name(&new_port).unwrap());
+    let mut conn_out = midi_out.connect(&new_port, "midir-test").unwrap();
     println!("Starting to send messages ...");
     conn_out.send(&[144, 60, 1]).unwrap();
     sleep(Duration::from_millis(200));
@@ -46,9 +48,11 @@ fn end_to_end() {
     println!("\nCreating virtual output port ...");
     let mut conn_out = midi_out.create_virtual("midir-test").unwrap();
     assert_eq!(midi_in.port_count(), previous_count + 1);
+
+    let new_port = midi_in.ports().into_iter().rev().next().unwrap();
     
-    println!("Connecting to port '{}' ...", midi_in.port_name(previous_count).unwrap());
-    let conn_in = midi_in.connect(previous_count, "midir-test", |stamp, message, _| {
+    println!("Connecting to port '{}' ...", midi_in.port_name(&new_port).unwrap());
+    let conn_in = midi_in.connect(&new_port, "midir-test", |stamp, message, _| {
         println!("{}: {:?} (len = {})", stamp, message, message.len());
     }, ()).unwrap();
     println!("Starting to send messages ...");


### PR DESCRIPTION
Implements #32.

This is not ready yet ... still missing:
- [x] Documentation
- [x] A way to get ports by value out of a `MidiInputPorts` or `MidiOutputPorts` collection (not possible via deref to slice)
- [x] CoreMIDI backend