### PR TITLE
add read input example

### DIFF
--- a/examples/test_read_input.rs
+++ b/examples/test_read_input.rs
@@ -1,0 +1,56 @@
+extern crate midir;
+
+use std::io::{stdin, stdout, Write};
+use std::error::Error;
+
+use midir::{MidiInput, Ignore};
+
+fn main() {
+    match run() {
+        Ok(_) => (),
+        Err(err) => println!("Error: {}", err.description())
+    }
+}
+
+fn run() -> Result<(), Box<Error>> {
+    let mut input = String::new();
+    
+    let mut midi_in = MidiInput::new("midir reading input")?;
+    midi_in.ignore(Ignore::None);
+    
+    // Get an input port (read from console if multiple are available)
+    let in_port = match midi_in.port_count() {
+        0 => return Err("no input port found".into()),
+        1 => {
+            println!("Choosing the only available input port: {}", midi_in.port_name(0).unwrap());
+            0
+        },
+        _ => {
+            println!("\nAvailable input ports:");
+            for i in 0..midi_in.port_count() {
+                println!("{}: {}", i, midi_in.port_name(i).unwrap());
+            }
+            print!("Please select input port: ");
+            stdout().flush()?;
+            let mut input = String::new();
+            stdin().read_line(&mut input)?;
+            input.trim().parse()?
+        }
+    };
+    
+    println!("\nOpening connections");
+    let in_port_name = midi_in.port_name(in_port)?;
+
+    // _conn_in needs to be a named parameter, because it needs to be kept alive until the end of the scope
+    let _conn_in = midi_in.connect(in_port, "midir-read-input", move |stamp, message, _| {
+        println!("{}: {:?} (len = {})", stamp, message, message.len());
+    }, ())?;
+    
+    println!("Connections open, reading input from '{}' (press enter to exit) ...", in_port_name);
+
+    input.clear();
+    stdin().read_line(&mut input)?; // wait for next enter key press
+
+    println!("Closing connections");
+    Ok(())
+}

--- a/examples/test_read_input.rs
+++ b/examples/test_read_input.rs
@@ -38,7 +38,7 @@ fn run() -> Result<(), Box<Error>> {
         }
     };
     
-    println!("\nOpening connections");
+    println!("\nOpening connection");
     let in_port_name = midi_in.port_name(in_port)?;
 
     // _conn_in needs to be a named parameter, because it needs to be kept alive until the end of the scope
@@ -46,11 +46,11 @@ fn run() -> Result<(), Box<Error>> {
         println!("{}: {:?} (len = {})", stamp, message, message.len());
     }, ())?;
     
-    println!("Connections open, reading input from '{}' (press enter to exit) ...", in_port_name);
+    println!("Connection open, reading input from '{}' (press enter to exit) ...", in_port_name);
 
     input.clear();
     stdin().read_line(&mut input)?; // wait for next enter key press
 
-    println!("Closing connections");
+    println!("Closing connection");
     Ok(())
 }


### PR DESCRIPTION
Thanks for your work on this crate. I wanted to use midir solely as a receiver of midi events, so this PR adds an example which doesn't require a midi output. 

It is very similar to some of the other examples, but I couldn't get the others to run because I don't have a midi output device to send to, I only have a midi input device. 