### PR TITLE
Web MIDI support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
+[workspace]
+members = [
+    ".",
+    "examples/browser",
+]
+
 [package]
 name = "midir"
 version = "0.5.0"
@@ -31,3 +37,21 @@ coremidi = "0.3.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["mmsystem", "mmeapi"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3"
+wasm-bindgen = "0.2"
+web-sys = { version = "0.3", features = [
+    "Event",
+    "Navigator",
+    "Window",
+    "MidiAccess",
+    "MidiInput",
+    "MidiInputMap",
+    "MidiMessageEvent",
+    "MidiOptions",
+    "MidiOutput",
+    "MidiOutputMap",
+    "MidiPort",
+    "MidiPortType"
+]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,6 @@ web-sys = { version = "0.3", features = [
     "MidiPort",
     "MidiPortType"
 ]}
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.2"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Cross-platform, realtime MIDI processing in Rust.
 - [x] CoreMIDI (macOS, iOS (untested))
 - [x] WinRT (Windows 8+), enable the `winrt` feature
 - [x] Jack (Linux, macOS), enable the `jack` feature
+- [x] Web MIDI (Chrome, Opera, perhaps others browsers)
 
 A higher-level API for parsing and assembling MIDI messages might be added in the future.
 

--- a/examples/browser/Cargo.toml
+++ b/examples/browser/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "midir_browser_example"
+version = "0.0.0"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+midir = { "path" = "../.." }
+
+console_error_panic_hook = "0.1.6"
+web-sys = { version = "0.3", features = ["console"]}
+js-sys = "0.3"
+wasm-bindgen = "0.2"

--- a/examples/browser/index.html
+++ b/examples/browser/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html><head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>midir &ndash; examples/browser</title>
+</head><body>
+    <script src="pkg/midir_browser_example.js"></script>
+    <script>
+        // fetch doesn't work over file:// in Chrome, despite using --allow-file-access-from-files, so use XHR instead.
+        var xhr = new XMLHttpRequest();
+        xhr.responseType = "arraybuffer";
+        xhr.addEventListener("load", function(load) {
+            wasm_bindgen(xhr.response).then(function(wasm) {});
+        });
+        xhr.open("GET", "pkg/midir_browser_example_bg.wasm");
+        xhr.send();
+    </script>
+</body></html>

--- a/examples/browser/src/lib.rs
+++ b/examples/browser/src/lib.rs
@@ -1,0 +1,82 @@
+extern crate midir;
+extern crate console_error_panic_hook;
+extern crate js_sys;
+extern crate web_sys;
+extern crate wasm_bindgen;
+
+use js_sys::{Array};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use web_sys::{console};
+
+use std::sync::{Arc, Mutex};
+use std::error::Error;
+
+use midir::{MidiInput, Ignore};
+
+pub fn log(s: String) {
+    console::log(&Array::of1(&s.into()));
+}
+
+macro_rules! println {
+    ()              => (log("".to_owned()));
+    ($($arg:tt)*)   => (log(format!($($arg)*)));
+}
+
+#[wasm_bindgen(start)]
+pub fn start() {
+    std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+
+    let token_outer = Arc::new(Mutex::new(None));
+    let token = token_outer.clone();
+    let closure : Closure<dyn FnMut()> = Closure::wrap(Box::new(move ||{
+        if run().unwrap() == true {
+            if let Some(token) = *token.lock().unwrap() {
+                web_sys::window().unwrap().clear_interval_with_handle(token);
+            }
+        }
+    }));
+    *token_outer.lock().unwrap() = web_sys::window().unwrap().set_interval_with_callback_and_timeout_and_arguments_0(
+        closure.as_ref().unchecked_ref(),
+        200,
+    ).ok();
+    closure.forget();
+}
+
+fn run() -> Result<bool, Box<dyn Error>> {
+    let mut midi_in = MidiInput::new("midir reading input")?;
+    midi_in.ignore(Ignore::None);
+
+    // Get an input port (TODO: prompt the user for which one they want if there are multiple, or open them all?)
+    let ports = midi_in.ports();
+    let in_port = match &ports[..] {
+        [] => {
+            println!("No ports available yet, will try again");
+            return Ok(false)
+        },
+        [ref port] => {
+            println!("Choosing the only available input port: {}", midi_in.port_name(port).unwrap());
+            port
+        },
+        _ => {
+            println!("Available input ports:");
+            for (i, port) in ports.iter().enumerate() {
+                println!("{}: {}", i, midi_in.port_name(port).unwrap());
+            }
+            println!("Using the first input port");
+            &ports[0]
+        }
+    };
+
+    println!("Opening connection");
+    let in_port_name = midi_in.port_name(in_port)?;
+
+    // _conn_in needs to be a named parameter, because it needs to be kept alive until the end of the scope
+    let _conn_in = midi_in.connect(in_port, "midir-read-input", move |stamp, message, _| {
+        println!("{}: {:?} (len = {})", stamp, message, message.len());
+    }, ())?;
+
+    println!("Connection open, reading input from '{}'", in_port_name);
+    Box::leak(Box::new(_conn_in));
+    Ok(true)
+}

--- a/examples/test_forward.rs
+++ b/examples/test_forward.rs
@@ -12,6 +12,7 @@ fn main() {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))] // conn_out is not `Send` in Web MIDI, which means it cannot be passed to connect
 fn run() -> Result<(), Box<Error>> {
     let mut input = String::new();
     
@@ -60,5 +61,11 @@ fn run() -> Result<(), Box<Error>> {
     stdin().read_line(&mut input)?; // wait for next enter key press
 
     println!("Closing connections");
+    Ok(())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn run() -> Result<(), Box<Error>> {
+    println!("test_forward cannot run on Web MIDI");
     Ok(())
 }

--- a/examples/test_sysex.rs
+++ b/examples/test_sysex.rs
@@ -7,7 +7,7 @@ fn main() {
     }
 }
 
-#[cfg(not(windows))] // virtual ports are not supported on Windows
+#[cfg(not(any(windows, target_arch = "wasm32")))] // virtual ports are not supported on Windows nor on Web MIDI
 mod example {
 
 use std::thread::sleep;
@@ -73,7 +73,7 @@ pub fn run() -> Result<(), Box<Error>> {
 }
 
  // needed to compile successfully
-#[cfg(windows)] mod example {
+#[cfg(any(windows, target_arch = "wasm32"))] mod example {
     use std::error::Error;
     pub fn run() -> Result<(), Box<Error>> { Ok(()) }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -17,3 +17,6 @@
 
 #[cfg(all(feature = "jack", not(target_os="windows")))] mod jack;
 #[cfg(all(feature = "jack", not(target_os="windows")))] pub use self::jack::*;
+
+#[cfg(target_arch="wasm32")] mod webmidi;
+#[cfg(target_arch="wasm32")] pub use self::webmidi::*;

--- a/src/backend/webmidi/mod.rs
+++ b/src/backend/webmidi/mod.rs
@@ -1,0 +1,248 @@
+//! Web MIDI Backend.
+//! 
+//! Reference:
+//! * [W3C Editor's Draft](https://webaudio.github.io/web-midi-api/)
+//! * [MDN web docs](https://developer.mozilla.org/en-US/docs/Web/API/MIDIAccess)
+
+extern crate js_sys;
+extern crate wasm_bindgen;
+extern crate web_sys;
+
+use self::js_sys::{Map, Promise, Uint8Array};
+use self::wasm_bindgen::prelude::*;
+use self::wasm_bindgen::JsCast;
+use self::web_sys::{MidiAccess, MidiOptions, MidiMessageEvent};
+
+use std::cell::RefCell;
+use std::sync::{Arc, Mutex};
+
+use ::errors::*;
+use ::Ignore;
+
+
+
+thread_local! {
+    static STATIC : RefCell<Static> = RefCell::new(Static::new());
+}
+
+struct Static {
+    pub access:         Option<MidiAccess>,
+    pub request:        Option<Promise>,
+    pub ever_requested: bool,
+
+    pub on_ok:          Closure<dyn FnMut(JsValue)>,
+    pub on_err:         Closure<dyn FnMut(JsValue)>,
+}
+
+impl Static {
+    pub fn new() -> Self {
+        let mut s = Self {
+            access:         None,
+            request:        None,
+            ever_requested: false,
+
+            on_ok: Closure::wrap(Box::new(|access| {
+                STATIC.with(|s|{
+                    let mut s = s.borrow_mut();
+                    let access : MidiAccess = access.dyn_into().unwrap();
+                    s.request = None;
+                    s.access = Some(access);
+                });
+            })),
+            on_err: Closure::wrap(Box::new(|_error| {
+                STATIC.with(|s|{
+                    let mut s = s.borrow_mut();
+                    s.request = None;
+                });
+            })),
+        };
+        // Some notes on sysex behavior:
+        //  1) Some devices (but not all!) may work without sysex
+        //  2) Chrome will only prompt the end user to grant permission if they requested sysex permissions for now...
+        //      but that's changing soon for "security reasons" (reduced fingerprinting? poorly tested drivers?):
+        //      https://www.chromestatus.com/feature/5138066234671104
+        //
+        //  I've chosen to hardcode sysex=true here, since that'll be compatible with more devices, *and* should change
+        //  less behavior when Chrome's changes land.
+        s.request_midi_access(true);
+        s
+    }
+
+    fn request_midi_access(&mut self, sysex: bool) {
+        self.ever_requested = true;
+        if self.access.is_some() { return; } // Already have access
+        if self.request.is_some() { return; } // Mid-request already
+        let window = if let Some(w) = web_sys::window() { w } else { return; };
+
+        let _request = match window.navigator().request_midi_access_with_options(MidiOptions::new().sysex(sysex)) {
+            Ok(p) => { self.request = Some(p.then2(&self.on_ok, &self.on_err)); },
+            Err(_) => { return; } // node.js? brower doesn't support webmidi? other?
+        };
+    }
+}
+
+pub struct MidiInputPort {
+    input: web_sys::MidiInput,
+}
+
+pub struct MidiInput {
+    ignore_flags: Ignore
+}
+
+impl MidiInput {
+    pub fn new(_client_name: &str) -> Result<Self, InitError> {
+        STATIC.with(|_|{});
+        Ok(MidiInput { ignore_flags: Ignore::None })
+    }
+
+    pub(crate) fn ports_internal(&self) -> Vec<::common::MidiInputPort> {
+        STATIC.with(|s|{
+            let mut v = Vec::new();
+            let s = s.borrow();
+            if let Some(access) = s.access.as_ref() {
+                let inputs : Map = access.inputs().unchecked_into();
+                inputs.for_each(&mut |value, _|{
+                    v.push(::common::MidiInputPort {
+                        imp: MidiInputPort { input: value.dyn_into().unwrap() }
+                    });
+                });
+            }
+            v
+        })
+    }
+
+    pub fn ignore(&mut self, flags: Ignore) {
+        self.ignore_flags = flags;
+    }
+
+    pub fn port_count(&self) -> usize {
+        STATIC.with(|s| {
+            let s = s.borrow();
+            s.access.as_ref().map(|access| access.inputs().unchecked_into::<Map>().size() as usize).unwrap_or(0)
+        })
+    }
+
+    pub fn port_name(&self, port: &MidiInputPort) -> Result<String, PortInfoError> {
+        Ok(port.input.name().unwrap_or_else(|| port.input.id()))
+    }
+
+    pub fn connect<F, T: Send + 'static>(
+        self, port: &MidiInputPort, _port_name: &str, mut callback: F, data: T
+    ) -> Result<MidiInputConnection<T>, ConnectError<MidiInput>>
+        where F: FnMut(u64, &[u8], &mut T) + Send + 'static
+    {
+        let input = port.input.clone();
+        let _ = input.open(); // NOTE: asyncronous!
+
+        let ignore_flags = self.ignore_flags;
+        let user_data = Arc::new(Mutex::new(Some(data)));
+
+        let closure = {
+            let user_data = user_data.clone();
+
+            let closure = Closure::wrap(Box::new(move |event: MidiMessageEvent| {
+                let time = (event.time_stamp() * 1000.0) as u64; // ms -> us
+                let buffer = event.data().unwrap();
+
+                let status = buffer[0];
+                if !(status == 0xF0 && ignore_flags.contains(Ignore::Sysex) ||
+                        status == 0xF1 && ignore_flags.contains(Ignore::Time) ||
+                        status == 0xF8 && ignore_flags.contains(Ignore::Time) ||
+                        status == 0xFE && ignore_flags.contains(Ignore::ActiveSense))
+                {
+                    callback(time, &buffer[..], user_data.lock().unwrap().as_mut().unwrap());
+                }
+            }) as Box<dyn FnMut(MidiMessageEvent)>);
+
+            input.set_onmidimessage(Some(closure.as_ref().unchecked_ref()));
+
+            closure
+        };
+
+        Ok(MidiInputConnection { ignore_flags, input, user_data, closure })
+    }
+}
+
+pub struct MidiInputConnection<T> {
+    ignore_flags:   Ignore,
+    input:          web_sys::MidiInput,
+    user_data:      Arc<Mutex<Option<T>>>,
+    #[allow(dead_code)] // Must be kept alive until we decide to unregister from input
+    closure:        Closure<dyn FnMut(MidiMessageEvent)>,
+}
+
+impl<T> MidiInputConnection<T> {
+    pub fn close(self) -> (MidiInput, T) {
+        let Self { ignore_flags, input, user_data, .. } = self;
+
+        input.set_onmidimessage(None);
+        let mut user_data = user_data.lock().unwrap();
+
+        (
+            MidiInput { ignore_flags },
+            user_data.take().unwrap()
+        )
+    }
+}
+
+pub struct MidiOutputPort {
+    output: web_sys::MidiOutput,
+}
+
+pub struct MidiOutput {
+}
+
+impl MidiOutput {
+    pub fn new(_client_name: &str) -> Result<Self, InitError> {
+        STATIC.with(|_|{});
+        Ok(MidiOutput {})
+    }
+
+    pub(crate) fn ports_internal(&self) -> Vec<::common::MidiOutputPort> {
+        STATIC.with(|s|{
+            let mut v = Vec::new();
+            let s = s.borrow();
+            if let Some(access) = s.access.as_ref() {
+                access.outputs().unchecked_into::<Map>().for_each(&mut |value, _|{
+                    v.push(::common::MidiOutputPort {
+                        imp: MidiOutputPort { output: value.dyn_into().unwrap() }
+                    });
+                });
+            }
+            v
+        })
+    }
+
+    pub fn port_count(&self) -> usize {
+        STATIC.with(|s|{
+            let s = s.borrow();
+            s.access.as_ref().map(|access| access.outputs().unchecked_into::<Map>().size() as usize).unwrap_or(0)
+        })
+    }
+
+    pub fn port_name(&self, port: &MidiOutputPort) -> Result<String, PortInfoError> {
+        Ok(port.output.name().unwrap_or_else(|| port.output.id()))
+    }
+
+    pub fn connect(self, port: &MidiOutputPort, _port_name: &str) -> Result<MidiOutputConnection, ConnectError<MidiOutput>> {
+        let _ = port.output.open(); // NOTE: asyncronous!
+        Ok(MidiOutputConnection{
+            output: port.output.clone()
+        })
+    }
+}
+
+pub struct MidiOutputConnection {
+    output: web_sys::MidiOutput,
+}
+
+impl MidiOutputConnection {
+    pub fn close(self) -> MidiOutput {
+        let _ = self.output.close(); // NOTE: asyncronous!
+        MidiOutput {}
+    }
+    
+    pub fn send(&mut self, message: &[u8]) -> Result<(), SendError> {
+        self.output.send(unsafe { Uint8Array::view(message) }.as_ref()).map_err(|_| SendError::Other("JavaScript exception"))
+    }
+}

--- a/src/common.rs
+++ b/src/common.rs
@@ -238,11 +238,13 @@ mod tests {
     fn test_trait_impls() {
         // make sure that all the structs implement `Send`
         fn is_send<T: Send>() {}
-        is_send::<MidiInputPort>();
         is_send::<MidiInput>();
-        is_send::<MidiInputConnection<()>>();
-        is_send::<MidiOutputPort>();
         is_send::<MidiOutput>();
-        is_send::<MidiOutputConnection>();
+        #[cfg(not(target_arch = "wasm32"))] {
+            is_send::<MidiInputPort>();
+            is_send::<MidiInputConnection<()>>();
+            is_send::<MidiOutputPort>();
+            is_send::<MidiOutputConnection>();
+        }
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -241,6 +241,9 @@ mod tests {
         is_send::<MidiInput>();
         is_send::<MidiOutput>();
         #[cfg(not(target_arch = "wasm32"))] {
+            // The story around threading and `Send` on WASM is not clear yet
+            // Tracking issue:      https://github.com/Boddlnagg/midir/issues/49
+            // Prev. discussion:    https://github.com/Boddlnagg/midir/pull/47
             is_send::<MidiInputPort>();
             is_send::<MidiInputConnection<()>>();
             is_send::<MidiOutputPort>();

--- a/tests/virtual.rs
+++ b/tests/virtual.rs
@@ -1,5 +1,5 @@
-//! This file contains automated tests, but they require virtual ports and therefore can't work on Windows ...
-#![cfg(not(windows))]
+//! This file contains automated tests, but they require virtual ports and therefore can't work on Windows or Web MIDI ...
+#![cfg(not(any(windows, target_arch = "wasm32")))]
 extern crate midir;
 
 use std::thread::sleep;


### PR DESCRIPTION
# Concerns

Web MIDI is all kinds of asyncronous.  Devices won't be available if you try to block request them immediately.  It's possible that sending a MIDI device input immediately after opening it, if that input device requires system exclusive access, may not work.  It'd perhaps be possible to buffer data until the promise for opening the device resolves...

# Testing

```cmd
C:\local\midir\examples\browser> wasm-pack build --target=no-modules --dev
...
C:\local\midir\examples\browser> "%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe" --allow-file-access-from-files --auto-open-devtools-for-tabs file:///C:\local\midir\examples\browser\index.html
```

Note that existing chrome instances may interfere with using command line flags - you may prefer to use the [msjsdiag.debugger-for-chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome) extension instead.  Snippets from my local .vscode config:

### .vscode\tasks.json

```json
{ "label": "examples/browser: wasm-pack build --target=no-modules --dev",       "options": { "cwd": "${workspaceFolder}/examples/browser" }, "windows": { "command": "wasm-pack build --target=no-modules --dev",       }, },
{ "label": "examples/browser: wasm-pack build --target=no-modules --profiling", "options": { "cwd": "${workspaceFolder}/examples/browser" }, "windows": { "command": "wasm-pack build --target=no-modules --profiling", }, },
{ "label": "examples/browser: wasm-pack build --target=no-modules --release",   "options": { "cwd": "${workspaceFolder}/examples/browser" }, "windows": { "command": "wasm-pack build --target=no-modules --release",   }, },
```

### .vscode\launch.json

```
        // msjsdiag.debugger-for-chrome
        // "runtimeArgs": See https://peter.sh/experiments/chromium-command-line-switches/
        {
            "name": "Chrome (--dev)", "type": "chrome", "request": "launch",
            "preLaunchTask": "examples/browser: wasm-pack build --target=no-modules --dev",
            "url": "${workspaceFolder}/examples/browser/index.html",
            "runtimeArgs": ["--allow-file-access-from-files", "--auto-open-devtools-for-tabs"],
            "internalConsoleOptions": "openOnSessionStart",
        },
        {
            "name": "Chrome (--profiling)", "type": "chrome", "request": "launch",
            "preLaunchTask": "examples/browser: wasm-pack build --target=no-modules --profiling",
            "url": "${workspaceFolder}/examples/browser/index.html",
            "runtimeArgs": ["--allow-file-access-from-files", "--auto-open-devtools-for-tabs"],
            "internalConsoleOptions": "openOnSessionStart",
        },
        {
            "name": "Chrome (--release)", "type": "chrome", "request": "launch",
            "preLaunchTask": "examples/browser: wasm-pack build --target=no-modules --release",
            "url": "${workspaceFolder}/examples/browser/index.html",
            "runtimeArgs": ["--allow-file-access-from-files", "--auto-open-devtools-for-tabs"],
            "internalConsoleOptions": "openOnSessionStart",
        },
```

# Screenshots

![image](https://user-images.githubusercontent.com/75894/64056543-d0a3f280-cb48-11e9-95f5-6c85d7dcd3d7.png)

![image](https://user-images.githubusercontent.com/75894/64056544-d4377980-cb48-11e9-95db-1c9bfbd9f6dd.png)
