### PR TITLE
Modernize / fix warnings

### DIFF
--- a/examples/test_forward.rs
+++ b/examples/test_forward.rs
@@ -8,7 +8,7 @@ use midir::{MidiInput, MidiOutput, Ignore};
 fn main() {
     match run() {
         Ok(_) => (),
-        Err(err) => println!("Error: {}", err.description())
+        Err(err) => println!("Error: {}", err)
     }
 }
 

--- a/examples/test_forward.rs
+++ b/examples/test_forward.rs
@@ -13,7 +13,7 @@ fn main() {
 }
 
 #[cfg(not(target_arch = "wasm32"))] // conn_out is not `Send` in Web MIDI, which means it cannot be passed to connect
-fn run() -> Result<(), Box<Error>> {
+fn run() -> Result<(), Box<dyn Error>> {
     let mut input = String::new();
     
     let mut midi_in = MidiInput::new("midir forwarding input")?;
@@ -65,7 +65,7 @@ fn run() -> Result<(), Box<Error>> {
 }
 
 #[cfg(target_arch = "wasm32")]
-fn run() -> Result<(), Box<Error>> {
+fn run() -> Result<(), Box<dyn Error>> {
     println!("test_forward cannot run on Web MIDI");
     Ok(())
 }

--- a/examples/test_list_ports.rs
+++ b/examples/test_list_ports.rs
@@ -8,7 +8,7 @@ use midir::{MidiInput, MidiOutput, Ignore};
 fn main() {
     match run() {
         Ok(_) => (),
-        Err(err) => println!("Error: {}", err.description())
+        Err(err) => println!("Error: {}", err)
     }
 }
 

--- a/examples/test_list_ports.rs
+++ b/examples/test_list_ports.rs
@@ -12,7 +12,7 @@ fn main() {
     }
 }
 
-fn run() -> Result<(), Box<Error>> {
+fn run() -> Result<(), Box<dyn Error>> {
     let mut midi_in = MidiInput::new("midir test input")?;
     midi_in.ignore(Ignore::None);
     let midi_out = MidiOutput::new("midir test output")?;

--- a/examples/test_play.rs
+++ b/examples/test_play.rs
@@ -14,7 +14,7 @@ fn main() {
     }
 }
 
-fn run() -> Result<(), Box<Error>> {
+fn run() -> Result<(), Box<dyn Error>> {
     let midi_out = MidiOutput::new("My Test Output")?;
     
     // Get an output port (read from console if multiple are available)

--- a/examples/test_play.rs
+++ b/examples/test_play.rs
@@ -10,7 +10,7 @@ use midir::{MidiOutput, MidiOutputPort};
 fn main() {
     match run() {
         Ok(_) => (),
-        Err(err) => println!("Error: {}", err.description())
+        Err(err) => println!("Error: {}", err)
     }
 }
 

--- a/examples/test_read_input.rs
+++ b/examples/test_read_input.rs
@@ -12,7 +12,7 @@ fn main() {
     }
 }
 
-fn run() -> Result<(), Box<Error>> {
+fn run() -> Result<(), Box<dyn Error>> {
     let mut input = String::new();
     
     let mut midi_in = MidiInput::new("midir reading input")?;

--- a/examples/test_read_input.rs
+++ b/examples/test_read_input.rs
@@ -8,7 +8,7 @@ use midir::{MidiInput, Ignore};
 fn main() {
     match run() {
         Ok(_) => (),
-        Err(err) => println!("Error: {}", err.description())
+        Err(err) => println!("Error: {}", err)
     }
 }
 

--- a/examples/test_reuse.rs
+++ b/examples/test_reuse.rs
@@ -14,7 +14,7 @@ fn main() {
     }
 }
 
-fn run() -> Result<(), Box<Error>> {
+fn run() -> Result<(), Box<dyn Error>> {
     let mut input = String::new();
     
     let mut midi_in = MidiInput::new("My Test Input")?;

--- a/examples/test_reuse.rs
+++ b/examples/test_reuse.rs
@@ -10,7 +10,7 @@ use midir::{MidiInput, MidiOutput, Ignore};
 fn main() {
     match run() {
         Ok(_) => (),
-        Err(err) => println!("Error: {}", err.description())
+        Err(err) => println!("Error: {}", err)
     }
 }
 

--- a/examples/test_sysex.rs
+++ b/examples/test_sysex.rs
@@ -19,7 +19,7 @@ use midir::os::unix::VirtualInput;
 
 const LARGE_SYSEX_SIZE: usize = 5572; // This is the maximum that worked for me
 
-pub fn run() -> Result<(), Box<Error>> {
+pub fn run() -> Result<(), Box<dyn Error>> {
     let mut midi_in = MidiInput::new("My Test Input")?;
     midi_in.ignore(Ignore::None);
     let midi_out = MidiOutput::new("My Test Output")?;
@@ -75,5 +75,5 @@ pub fn run() -> Result<(), Box<Error>> {
  // needed to compile successfully
 #[cfg(any(windows, target_arch = "wasm32"))] mod example {
     use std::error::Error;
-    pub fn run() -> Result<(), Box<Error>> { Ok(()) }
+    pub fn run() -> Result<(), Box<dyn Error>> { Ok(()) }
 }

--- a/examples/test_sysex.rs
+++ b/examples/test_sysex.rs
@@ -3,7 +3,7 @@ extern crate midir;
 fn main() {
     match example::run() {
         Ok(_) => (),
-        Err(err) => println!("Error: {}", err.description())
+        Err(err) => println!("Error: {}", err)
     }
 }
 

--- a/src/backend/alsa/mod.rs
+++ b/src/backend/alsa/mod.rs
@@ -136,7 +136,7 @@ struct HandlerData<T: 'static> {
     ignore_flags: Ignore,
     seq: Seq,
     trigger_rcv_fd: i32,
-    callback: Box<FnMut(u64, &[u8], &mut T) + Send>,
+    callback: Box<dyn FnMut(u64, &[u8], &mut T) + Send>,
     queue_id: i32, // an input queue is needed to get timestamped events
 }
 

--- a/src/backend/alsa/mod.rs
+++ b/src/backend/alsa/mod.rs
@@ -586,7 +586,7 @@ impl Drop for MidiOutputConnection {
 
 fn handle_input<T>(mut data: HandlerData<T>, user_data: &mut T) -> HandlerData<T> {
     use self::alsa::PollDescriptors;
-    use self::alsa::seq::{EventType, Connect};
+    use self::alsa::seq::Connect;
 
     let mut continue_sysex: bool = false;
     

--- a/src/backend/coremidi/mod.rs
+++ b/src/backend/coremidi/mod.rs
@@ -237,7 +237,7 @@ struct HandlerData<T> {
     message: MidiMessage,
     ignore_flags: Ignore,
     continue_sysex: bool,
-    callback: Box<FnMut(u64, &[u8], &mut T) + Send>,
+    callback: Box<dyn FnMut(u64, &[u8], &mut T) + Send>,
     user_data: Option<T>
 }
 

--- a/src/backend/jack/mod.rs
+++ b/src/backend/jack/mod.rs
@@ -18,7 +18,7 @@ const OUTPUT_RINGBUFFER_SIZE: usize = 16384;
 struct InputHandlerData<T> {
     port: Option<MidiPort>,
     ignore_flags: Ignore,
-    callback: Box<FnMut(u64, &[u8], &mut T) + Send>,
+    callback: Box<dyn FnMut(u64, &[u8], &mut T) + Send>,
     user_data: Option<T>
 }
 

--- a/src/backend/jack/wrappers.rs
+++ b/src/backend/jack/wrappers.rs
@@ -37,7 +37,7 @@ use super::jack_sys::{
     jack_ringbuffer_write,
 };
 
-pub const JACK_DEFAULT_MIDI_TYPE: &'static [u8] = b"8 bit raw midi\0";
+pub const JACK_DEFAULT_MIDI_TYPE: &[u8] = b"8 bit raw midi\0";
 
 bitflags! {
     flags JackOpenOptions: u32 {

--- a/src/backend/winmm/mod.rs
+++ b/src/backend/winmm/mod.rs
@@ -136,7 +136,7 @@ struct HandlerData<T> {
     sysex_buffer: SysexBuffer,
     in_handle: Option<MidiInHandle>,
     ignore_flags: Ignore,
-    callback: Box<FnMut(u64, &[u8], &mut T) + Send + 'static>,
+    callback: Box<dyn FnMut(u64, &[u8], &mut T) + Send + 'static>,
     user_data: Option<T>
 }
 

--- a/src/backend/winrt/mod.rs
+++ b/src/backend/winrt/mod.rs
@@ -156,7 +156,7 @@ impl<T> MidiInputConnection<T> {
 /// offsets after monomorphization.
 struct HandlerData<T> {
     ignore_flags: Ignore,
-    callback: Box<FnMut(u64, &[u8], &mut T) + Send>,
+    callback: Box<dyn FnMut(u64, &[u8], &mut T) + Send>,
     user_data: Option<T>
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,15 +10,11 @@ const CANNOT_RETRIEVE_PORT_NAME_MSG: &'static str = "unknown error when trying t
 /// creating a `MidiInput` or `MidiOutput` object).
 pub struct InitError;
 
-impl Error for InitError {
-    fn description(&self) -> &str {
-        "MIDI support could not be initialized"
-    }
-}
+impl Error for InitError {}
 
 impl fmt::Display for InitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.description().fmt(f)
+        "MIDI support could not be initialized".fmt(f)
     }
 }
 
@@ -31,19 +27,15 @@ pub enum PortInfoError {
     CannotRetrievePortName,
 }
 
-impl Error for PortInfoError {
-    fn description(&self) -> &str {
-        match *self {
-            PortInfoError::PortNumberOutOfRange => PORT_OUT_OF_RANGE_MSG,
-            PortInfoError::InvalidPort => INVALID_PORT_MSG,
-            PortInfoError::CannotRetrievePortName => CANNOT_RETRIEVE_PORT_NAME_MSG,
-        }
-    }
-}
+impl Error for PortInfoError {}
 
 impl fmt::Display for PortInfoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.description().fmt(f)
+        match *self {
+            PortInfoError::PortNumberOutOfRange => PORT_OUT_OF_RANGE_MSG.fmt(f),
+            PortInfoError::InvalidPort => INVALID_PORT_MSG.fmt(f),
+            PortInfoError::CannotRetrievePortName => CANNOT_RETRIEVE_PORT_NAME_MSG.fmt(f),
+        }
     }
 }
 
@@ -54,18 +46,14 @@ pub enum ConnectErrorKind {
     Other(&'static str)
 }
 
-impl ConnectErrorKind {
-    fn description(&self) -> &str {
-        match *self {
-            ConnectErrorKind::InvalidPort => INVALID_PORT_MSG,
-            ConnectErrorKind::Other(msg) => msg
-        }
-    }
-}
+impl ConnectErrorKind {}
 
 impl fmt::Display for ConnectErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.description().fmt(f)
+        match *self {
+            ConnectErrorKind::InvalidPort => INVALID_PORT_MSG.fmt(f),
+            ConnectErrorKind::Other(msg) => msg.fmt(f)
+        }
     }
 }
 
@@ -106,11 +94,7 @@ impl<T> fmt::Display for ConnectError<T> {
     }
 }
 
-impl<T> Error for ConnectError<T> {
-    fn description(&self) -> &str {
-        self.kind.description()
-    }
-}
+impl<T> Error for ConnectError<T> {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// An error that can occur when sending MIDI messages.
@@ -119,16 +103,12 @@ pub enum SendError {
     Other(&'static str)
 }
 
-impl Error for SendError {
-    fn description(&self) -> &str {
-        match *self {
-            SendError::InvalidData(msg) | SendError::Other(msg) => msg
-        }
-    }
-}
+impl Error for SendError {}
 
 impl fmt::Display for SendError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.description().fmt(f)
+        match *self {
+            SendError::InvalidData(msg) | SendError::Other(msg) => msg.fmt(f)
+        }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,9 +1,9 @@
 use std::error::Error;
 use std::fmt;
 
-const INVALID_PORT_MSG: &'static str = "invalid port";
-const PORT_OUT_OF_RANGE_MSG: &'static str = "provided port number was out of range";
-const CANNOT_RETRIEVE_PORT_NAME_MSG: &'static str = "unknown error when trying to retrieve the port name";
+const INVALID_PORT_MSG: &str = "invalid port";
+const PORT_OUT_OF_RANGE_MSG: &str = "provided port number was out of range";
+const CANNOT_RETRIEVE_PORT_NAME_MSG: &str = "unknown error when trying to retrieve the port name";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// An error that can occur during initialization (i.e., while


### PR DESCRIPTION
Hi. Really nice library! I want to get in to coding my MIDI things using Rust.

However, when building the examples I noticed a number of warnings. Many of them deprecation warnings. But they are easily fixed. So I thought I'd brush it up a little bit.

* `Error::description` has been soft deprecated since Rust 1.27 and was hard deprecated in 1.42. So I remove those implementations and let users rely on the `Display` impl of errors. Should maybe be considered a breaking change in a way. The exposed API is identical, but user's will get nonsense messages if they still call `.description()` after this lands.
* Trait objects without the `dyn` keyword are deprecated. So I just added the `dyn` keyword.
* Constants default to the static lifetime. There is no other lifetime they can have. So the `'static` part can be omitted.
* The compiler complained about one redundant import in the alsa backend.

I also see now that my editor automatically inserted a newline at the end of files I touched. I can back that out if you don't like it.