### PR TITLE
WIP: Remove 'static constraint on callbacks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ winrt = { version = "0.6.0", features = ["windows-devices", "windows-storage"], 
 alsa = "0.2"
 nix = "0.9"
 libc = "0.2.21"
+thread-scoped = "1.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 coremidi = "0.4.0"

--- a/src/backend/alsa/mod.rs
+++ b/src/backend/alsa/mod.rs
@@ -3,7 +3,6 @@ extern crate alsa;
 extern crate nix;
 
 use std::mem;
-use std::thread::{Builder, JoinHandle};
 use std::io::{stderr, Write};
 use std::ffi::{CString, CStr};
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -53,7 +53,7 @@ pub struct MidiInput {
     imp: MidiInputImpl
 }
 
-impl<'a> MidiInput {
+impl MidiInput {
     /// Creates a new `MidiInput` object that is required for any MIDI input functionality.
     pub fn new(client_name: &str) -> Result<Self, InitError> {
         MidiInputImpl::new(client_name).map(|imp| MidiInput { imp: imp })
@@ -106,7 +106,7 @@ impl<'a> MidiInput {
     ///
     /// An error will be returned when the port is no longer valid
     /// (e.g. the respective device has been disconnected).
-    pub fn connect<F, T: Send>(
+    pub fn connect<'a, F, T: Send>(
         self, port: &MidiInputPort, port_name: &str, callback: F, data: T
     ) -> Result<MidiInputConnection<'a, T>, ConnectError<MidiInput>>
         where F: FnMut(u64, &[u8], &mut T) + Send + 'a {


### PR DESCRIPTION
As discussed in #44, this removes the 'static constraint on message callbacks by leveraging the `thread-scoped` crate.

So far I made the ALSA, JACK and WinMM backend work.