### PR TITLE
Remove usage of mem::uninitialized

### DIFF
--- a/src/backend/jack/mod.rs
+++ b/src/backend/jack/mod.rs
@@ -177,12 +177,12 @@ extern "C" fn handle_input<T>(nframes: jack_nframes_t, arg: *mut c_void) -> i32 
         
         // We have midi events in buffer
         let evcount = buff.get_event_count();
-        let mut event = unsafe { mem::uninitialized() };
+        let mut event = mem::MaybeUninit::uninit();
         
         for j in 0..evcount {
             message.bytes.clear();
-            
-            unsafe { buff.get_event(&mut event, j) };
+            unsafe { buff.get_event(event.as_mut_ptr(), j) };
+            let event = unsafe { event.assume_init() };
             
             for i in 0..event.size {
                 message.bytes.push(unsafe { *event.buffer.offset(i as isize) });

--- a/src/backend/jack/wrappers.rs
+++ b/src/backend/jack/wrappers.rs
@@ -204,7 +204,7 @@ impl MidiBuffer {
         unsafe { jack_midi_get_event_count(self.p) }
     }
     
-    pub unsafe fn get_event(&self, ev: &mut jack_midi_event_t, index: u32) {
+    pub unsafe fn get_event(&self, ev: *mut jack_midi_event_t, index: u32) {
         jack_midi_event_get(ev, self.p, index);
     }
     


### PR DESCRIPTION
Hi! 

`std::mem::uninitialized` was [deprecated in Rust 1.39.0](https://doc.rust-lang.org/std/mem/fn.uninitialized.html), and the recommended pattern is to replace it with `std::mem::MaybeUninit`.  This is a little PR to migrate in case downstream crates forbid the use of deprecated calls (my use case)

* Replaces calls to uninitialized() with MaybeUninit where appropriate
* Replace uninitialized memory in SysexBuffer with array of null pointers instead, which can be checked in the case of failure.
