### PR TITLE
Update dependencies (alsa to 0.4.2, nix to 0.15)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ libc = { version = "0.2.21", optional = true }
 winrt = { version = "0.7.0", optional = true}
 
 [target.'cfg(target_os = "linux")'.dependencies]
-alsa = "0.2"
-nix = "0.9"
+alsa = "0.4.2"
+nix = "0.15"
 libc = "0.2.21"
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
Fixes #62 (Update alsa dependency to 0.4.2)

In order to update _alsa_, I had also to update _nix_ to avoid further compile errors. 