### PR TITLE
Implement PartialEq For Midi Ports

### DIFF
--- a/src/backend/alsa/mod.rs
+++ b/src/backend/alsa/mod.rs
@@ -121,7 +121,7 @@ pub struct MidiInput {
     seq: Option<Seq>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct MidiInputPort {
     addr: Addr
 }
@@ -432,7 +432,7 @@ pub struct MidiOutput {
     seq: Option<Seq>, // TODO: if `Seq` is marked as non-zero, this should just be pointer-sized 
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct MidiOutputPort {
     addr: Addr
 }

--- a/src/backend/coremidi/mod.rs
+++ b/src/backend/coremidi/mod.rs
@@ -26,6 +26,17 @@ pub struct MidiInputPort {
     source: Arc<Source>
 }
 
+impl PartialEq for MidiInputPort {
+    fn eq(&self, other: &Self) -> bool {
+        if let (Some(id1), Some(id2)) = (self.source.unique_id(), other.unique_id()) {
+            id1 == id2
+        } else {
+            // Acording to macos docs "The system assigns unique IDs to all objects.", so I think we can ignore this case
+            false
+        }
+    }
+}
+
 impl MidiInput {
     pub fn new(client_name: &str) -> Result<Self, InitError> {
         match Client::new(client_name) {
@@ -249,6 +260,17 @@ pub struct MidiOutput {
 #[derive(Clone)]
 pub struct MidiOutputPort {
     dest: Arc<Destination>
+}
+
+impl PartialEq for MidiOutputPort {
+    fn eq(&self, other: &Self) -> bool {
+        if let (Some(id1), Some(id2)) = (self.source.unique_id(), other.unique_id()) {
+            id1 == id2
+        } else {
+            // Acording to macos docs "The system assigns unique IDs to all objects.", so I think we can ignore this case
+            false
+        }
+    }
 }
 
 impl MidiOutput {

--- a/src/backend/coremidi/mod.rs
+++ b/src/backend/coremidi/mod.rs
@@ -28,7 +28,7 @@ pub struct MidiInputPort {
 
 impl PartialEq for MidiInputPort {
     fn eq(&self, other: &Self) -> bool {
-        if let (Some(id1), Some(id2)) = (self.source.unique_id(), other.unique_id()) {
+        if let (Some(id1), Some(id2)) = (self.source.unique_id(), other.source.unique_id()) {
             id1 == id2
         } else {
             // Acording to macos docs "The system assigns unique IDs to all objects.", so I think we can ignore this case
@@ -264,7 +264,7 @@ pub struct MidiOutputPort {
 
 impl PartialEq for MidiOutputPort {
     fn eq(&self, other: &Self) -> bool {
-        if let (Some(id1), Some(id2)) = (self.source.unique_id(), other.unique_id()) {
+        if let (Some(id1), Some(id2)) = (self.dest.unique_id(), other.dest.unique_id()) {
             id1 == id2
         } else {
             // Acording to macos docs "The system assigns unique IDs to all objects.", so I think we can ignore this case

--- a/src/backend/jack/mod.rs
+++ b/src/backend/jack/mod.rs
@@ -27,7 +27,7 @@ pub struct MidiInput {
     client: Option<Client>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct MidiInputPort {
     name: CString
 }
@@ -206,7 +206,7 @@ pub struct MidiOutput {
     client: Option<Client>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct MidiOutputPort {
     name: CString
 }

--- a/src/backend/webmidi/mod.rs
+++ b/src/backend/webmidi/mod.rs
@@ -81,7 +81,7 @@ impl Static {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct MidiInputPort {
     input: web_sys::MidiInput,
 }
@@ -186,7 +186,7 @@ impl<T> MidiInputConnection<T> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct MidiOutputPort {
     output: web_sys::MidiOutput,
 }

--- a/src/backend/winmm/mod.rs
+++ b/src/backend/winmm/mod.rs
@@ -57,6 +57,12 @@ pub struct MidiInputPort {
     interface_id: Box<[u16]>
 }
 
+impl PartialEq for MidiInputPort {
+    fn eq(&self, other: &Self) -> bool {
+        self.interface_id == other.interface_id
+    }
+}
+
 pub struct MidiInputConnection<T> {
     handler_data: Box<HandlerData<T>>,
 }
@@ -309,6 +315,12 @@ pub struct MidiOutput;
 pub struct MidiOutputPort {
     name: String,
     interface_id: Box<[u16]>
+}
+
+impl PartialEq for MidiOutputPort {
+    fn eq(&self, other: &Self) -> bool {
+        self.interface_id == other.interface_id
+    }
 }
 
 pub struct MidiOutputConnection {

--- a/src/backend/winrt/mod.rs
+++ b/src/backend/winrt/mod.rs
@@ -22,7 +22,7 @@ use self::windows::devices::midi::*;
 use self::windows::devices::enumeration::DeviceInformation;
 use self::windows::storage::streams::{Buffer, DataWriter};
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct MidiInputPort {
     id: HString
 }
@@ -219,7 +219,7 @@ struct HandlerData<T> {
     user_data: Option<T>
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct MidiOutputPort {
     id: HString
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -38,7 +38,7 @@ pub trait MidiIO {
 ///
 /// Use the `ports` method of a `MidiInput` instance to obtain
 /// available ports.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct MidiInputPort {
     pub(crate) imp: MidiInputPortImpl
 }
@@ -175,7 +175,7 @@ impl<T> MidiInputConnection<T> {
 ///
 /// Use the `ports` method of a `MidiOutput` instance to obtain
 /// available ports.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct MidiOutputPort {
     pub(crate) imp: MidiOutputPortImpl
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -303,5 +303,13 @@ mod tests {
             is_send::<MidiOutputPort>();
             is_send::<MidiOutputConnection>();
         }
+
+        // make sure that Midi port structs implement `PartialEq`
+        fn is_partial_eq<T: PartialEq>() {}
+        is_partial_eq::<MidiInputPortImpl>();
+        is_partial_eq::<MidiOutputPortImpl>();
+
+        is_partial_eq::<MidiInputPort>();
+        is_partial_eq::<MidiOutputPort>();
     }
 }


### PR DESCRIPTION
It would be useful if we could compare ports directly by their identificator.