### PR TITLE
Opt-in support for JACK backend on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "midir"
-version = "0.8.0"
+version = "0.7.0"
 authors = ["Patrick Reisert"]
 description = "A cross-platform, realtime MIDI processing library, inspired by RtMidi."
 repository = "https://github.com/Boddlnagg/midir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "midir"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Patrick Reisert"]
 description = "A cross-platform, realtime MIDI processing library, inspired by RtMidi."
 repository = "https://github.com/Boddlnagg/midir"
@@ -19,11 +19,12 @@ license = "MIT"
 default = []
 avoid_timestamping = []
 jack = ["jack-sys", "libc"]
+winjack = ["jack"]
 
 [dependencies]
 bitflags = "1.2"
 memalloc = "0.1.0"
-jack-sys = { version = "0.1.0", optional = true }
+jack-sys = { version = "0.2.3", optional = true }
 libc = { version = "0.2.21", optional = true }
 winrt = { version = "0.7.0", optional = true}
 

--- a/examples/test_forward.rs
+++ b/examples/test_forward.rs
@@ -1,5 +1,9 @@
 extern crate midir;
 
+#[cfg(all(windows, feature = "winjack"))]
+#[link(name = "C:/Program Files/JACK2/lib/libjack64")]
+extern "C" {}
+
 use std::io::{stdin, stdout, Write};
 use std::error::Error;
 

--- a/examples/test_list_ports.rs
+++ b/examples/test_list_ports.rs
@@ -1,5 +1,9 @@
 extern crate midir;
 
+#[cfg(all(windows, feature = "winjack"))]
+#[link(name = "C:/Program Files/JACK2/lib/libjack64")]
+extern "C" {}
+
 use std::io::{stdin, stdout, Write};
 use std::error::Error;
 

--- a/examples/test_play.rs
+++ b/examples/test_play.rs
@@ -1,5 +1,9 @@
 extern crate midir;
 
+#[cfg(all(windows, feature = "winjack"))]
+#[link(name = "C:/Program Files/JACK2/lib/libjack64")]
+extern "C" {}
+
 use std::thread::sleep;
 use std::time::Duration;
 use std::io::{stdin, stdout, Write};

--- a/examples/test_read_input.rs
+++ b/examples/test_read_input.rs
@@ -1,5 +1,9 @@
 extern crate midir;
 
+#[cfg(all(windows, feature = "winjack"))]
+#[link(name = "C:/Program Files/JACK2/lib/libjack64")]
+extern "C" {}
+
 use std::io::{stdin, stdout, Write};
 use std::error::Error;
 

--- a/examples/test_reuse.rs
+++ b/examples/test_reuse.rs
@@ -1,5 +1,9 @@
 extern crate midir;
 
+#[cfg(all(windows, feature = "winjack"))]
+#[link(name = "C:/Program Files/JACK2/lib/libjack64")]
+extern "C" {}
+
 use std::thread::sleep;
 use std::time::Duration;
 use std::io::{stdin, stdout, Write};

--- a/examples/test_sysex.rs
+++ b/examples/test_sysex.rs
@@ -1,5 +1,9 @@
 extern crate midir;
 
+#[cfg(all(windows, feature = "winjack"))]
+#[link(name = "C:/Program Files/JACK2/lib/libjack64")]
+extern "C" {}
+
 fn main() {
     match example::run() {
         Ok(_) => (),
@@ -7,7 +11,7 @@ fn main() {
     }
 }
 
-#[cfg(not(any(windows, target_arch = "wasm32")))] // virtual ports are not supported on Windows nor on Web MIDI
+#[cfg(not(any(all(windows,not(feature = "winjack")), target_arch = "wasm32")))] // virtual ports are not supported on Windows nor on Web MIDI
 mod example {
 
 use std::thread::sleep;
@@ -15,7 +19,7 @@ use std::time::Duration;
 use std::error::Error;
 
 use midir::{MidiInput, MidiOutput, Ignore};
-use midir::os::unix::VirtualInput;
+use midir::r#virtual::VirtualInput;
 
 const LARGE_SYSEX_SIZE: usize = 5572; // This is the maximum that worked for me
 
@@ -73,7 +77,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
 }
 
  // needed to compile successfully
-#[cfg(any(windows, target_arch = "wasm32"))] mod example {
+#[cfg(any(all(windows, not(feature = "winjack")), target_arch = "wasm32"))] mod example {
     use std::error::Error;
     pub fn run() -> Result<(), Box<dyn Error>> { Ok(()) }
 }

--- a/src/backend/jack/mod.rs
+++ b/src/backend/jack/mod.rs
@@ -13,7 +13,6 @@ use self::wrappers::*;
 use ::{Ignore, MidiMessage};
 use ::errors::*;
 
-
 const OUTPUT_RINGBUFFER_SIZE: usize = 16384;
 
 struct InputHandlerData<T> {

--- a/src/backend/jack/mod.rs
+++ b/src/backend/jack/mod.rs
@@ -13,6 +13,7 @@ use self::wrappers::*;
 use ::{Ignore, MidiMessage};
 use ::errors::*;
 
+
 const OUTPUT_RINGBUFFER_SIZE: usize = 16384;
 
 struct InputHandlerData<T> {

--- a/src/backend/jack/wrappers.rs
+++ b/src/backend/jack/wrappers.rs
@@ -83,7 +83,7 @@ impl Client {
     }
     
     pub fn get_midi_ports(&self, flags: PortFlags) -> PortInfos {
-        let ports_ptr = unsafe { jack_get_ports(self.p, ptr::null_mut(), JACK_DEFAULT_MIDI_TYPE.as_ptr() as *const i8, flags.bits() as u64) };
+        let ports_ptr = unsafe { jack_get_ports(self.p, ptr::null_mut(), JACK_DEFAULT_MIDI_TYPE.as_ptr() as *const i8, flags.bits() as u32) };
         let slice = if ports_ptr.is_null() {
             &[]
         } else {
@@ -97,7 +97,7 @@ impl Client {
     
     pub fn register_midi_port(&mut self, name: &str, flags: PortFlags) -> Result<MidiPort, ()> {
         let c_name = CString::new(name).ok().expect("port name must not contain null bytes");
-        let result = unsafe { jack_port_register(self.p, c_name.as_ptr(), JACK_DEFAULT_MIDI_TYPE.as_ptr() as *const i8, flags.bits() as u64, 0) };
+        let result = unsafe { jack_port_register(self.p, c_name.as_ptr(), JACK_DEFAULT_MIDI_TYPE.as_ptr() as *const i8, flags.bits() as u32, 0) };
         if result.is_null() {
             Err(())
         } else {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3,11 +3,11 @@
 // TODO: improve feature selection (make sure that there is always exactly one implementation, or enable dynamic backend selection)
 // TODO: allow to disable build dependency on ALSA
 
-#[cfg(all(target_os="windows", not(feature = "winrt")))] mod winmm;
-#[cfg(all(target_os="windows", not(feature = "winrt")))] pub use self::winmm::*;
+#[cfg(all(target_os="windows", not(any(feature = "winrt", feature = "winjack"))))] mod winmm;
+#[cfg(all(target_os="windows", not(any(feature = "winrt", feature = "winjack"))))] pub use self::winmm::*;
 
-#[cfg(all(target_os="windows", feature = "winrt"))] mod winrt;
-#[cfg(all(target_os="windows", feature = "winrt"))] pub use self::winrt::*;
+#[cfg(all(target_os="windows", feature = "winrt", not(feature = "winjack")))] mod winrt;
+#[cfg(all(target_os="windows", feature = "winrt", not(feature = "winjack")))] pub use self::winrt::*;
 
 #[cfg(all(target_os="macos", not(feature = "jack")))] mod coremidi;
 #[cfg(all(target_os="macos", not(feature = "jack")))] pub use self::coremidi::*;
@@ -15,8 +15,8 @@
 #[cfg(all(target_os="linux", not(feature = "jack")))] mod alsa;
 #[cfg(all(target_os="linux", not(feature = "jack")))] pub use self::alsa::*;
 
-#[cfg(all(feature = "jack", not(target_os="windows")))] mod jack;
-#[cfg(all(feature = "jack", not(target_os="windows")))] pub use self::jack::*;
+#[cfg(all(feature = "jack", any(unix, feature = "winjack")))] mod jack;
+#[cfg(all(feature = "jack", any(unix, feature = "winjack")))] pub use self::jack::*;
 
 #[cfg(target_arch="wasm32")] mod webmidi;
 #[cfg(target_arch="wasm32")] pub use self::webmidi::*;

--- a/src/common.rs
+++ b/src/common.rs
@@ -136,8 +136,8 @@ impl MidiIO for MidiInput {
     }
 }
 
-#[cfg(unix)]
-impl<T: Send> ::os::unix::VirtualInput<T> for MidiInput {
+#[cfg(any(unix, feature = "winjack"))]
+impl<T: Send> ::r#virtual::VirtualInput<T> for MidiInput {
     fn create_virtual<F>(
         self, port_name: &str, callback: F, data: T
     ) -> Result<MidiInputConnection<T>, ConnectError<Self>>
@@ -252,8 +252,8 @@ impl MidiIO for MidiOutput {
     }
 }
 
-#[cfg(unix)]
-impl ::os::unix::VirtualOutput for MidiOutput {
+#[cfg(any(unix, feature = "winjack"))]
+impl ::r#virtual::VirtualOutput for MidiOutput {
     fn create_virtual(self, port_name: &str) -> Result<MidiOutputConnection, ConnectError<MidiOutput>> {
         match self.imp.create_virtual(port_name) {
             Ok(imp) => Ok(MidiOutputConnection { imp: imp }),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(all(feature = "winjack", feature = "winrt"))]
+compile_error!("feature \"winjack\" and \"winrt\" cannot be enabled at the same time");
+
 extern crate memalloc;
 
 #[cfg(feature = "jack")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ impl MidiMessage {
     }
 }
 
-pub mod os; // include platform-specific behaviour
+#[cfg(any(unix, feature = "winjack"))] pub mod r#virtual;
 
 mod errors;
 pub use errors::*;

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -1,1 +1,0 @@
-#[cfg(unix)] pub mod unix;

--- a/src/virtual.rs
+++ b/src/virtual.rs
@@ -2,7 +2,7 @@ use ::ConnectError;
 use ::{MidiInputConnection, MidiOutputConnection};
 
 /// Trait that is implemented by `MidiInput` on platforms that
-/// support virtual ports (currently every platform but Windows).
+/// support virtual ports (currently every platform but winmm and winrt).
 pub trait VirtualInput<T: Send> where Self: Sized {
     /// Creates a virtual input port. Once it has been created,
     /// other applications can connect to this port and send MIDI
@@ -14,7 +14,7 @@ pub trait VirtualInput<T: Send> where Self: Sized {
 }
 
 /// Trait that is implemented by `MidiOutput` on platforms that
-/// support virtual ports (currently every platform but Windows).
+/// support virtual ports (currently every platform but winmm and winrt).
 pub trait VirtualOutput where Self: Sized {
     /// Creates a virtual output port. Once it has been created,
     /// other applications can connect to this port and will

--- a/src/virtual.rs
+++ b/src/virtual.rs
@@ -1,8 +1,6 @@
 use ::ConnectError;
 use ::{MidiInputConnection, MidiOutputConnection};
 
-// TODO: maybe move to module `virtual` instead of `os::unix`?
-
 /// Trait that is implemented by `MidiInput` on platforms that
 /// support virtual ports (currently every platform but Windows).
 pub trait VirtualInput<T: Send> where Self: Sized {

--- a/tests/virtual.rs
+++ b/tests/virtual.rs
@@ -1,12 +1,17 @@
 //! This file contains automated tests, but they require virtual ports and therefore can't work on Windows or Web MIDI ...
-#![cfg(not(any(windows, target_arch = "wasm32")))]
+
+#![cfg(not(any(all(windows, not(feature = "winjack")), target_arch = "wasm32")))]
 extern crate midir;
+
+#[cfg(all(windows, feature = "winjack"))]
+#[link(name = "C:/Program Files/JACK2/lib/libjack64")]
+extern "C" {}
 
 use std::thread::sleep;
 use std::time::Duration;
 
 use midir::{MidiInput, MidiOutput, Ignore, MidiOutputPort};
-use midir::os::unix::{VirtualInput, VirtualOutput};
+use midir::r#virtual::{VirtualInput, VirtualOutput};
 
 #[test]
 fn end_to_end() {


### PR DESCRIPTION
- Adds `winjack` feature to allow using JACK as the backend on Windows (non-breaking)
- moves VirtualInput and VirtualOutput out of the `os` module and into their own `virtual` module (breaking)

`jack-sys` doesn't provide a link to libjack on Windows, so consumers will need to supply their own. I included linking to JACK2 at the standard installation path for the integration test and examples.