### PR TITLE
Update alsa to 0.6.0 to support riscv64 target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,7 @@ libc = { version = "0.2.21", optional = true }
 winrt = { version = "0.7.0", optional = true}
 
 [target.'cfg(target_os = "linux")'.dependencies]
-alsa = "0.4.3"
-nix = "0.15"
+alsa = "0.6.0"
 libc = "0.2.21"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/backend/alsa/mod.rs
+++ b/src/backend/alsa/mod.rs
@@ -1,6 +1,5 @@
 extern crate libc;
 extern crate alsa;
-extern crate nix;
 
 use std::mem;
 use std::thread::{Builder, JoinHandle};
@@ -651,11 +650,11 @@ fn handle_input<T>(mut data: HandlerData<T>, user_data: &mut T) -> HandlerData<T
         // If here, there should be data.
         let mut ev = match seq_input.event_input() {
             Ok(ev) => ev,
-            Err(ref e) if e.errno() == Some(self::nix::errno::Errno::ENOSPC) => {
+            Err(ref e) if e.errno() == alsa::nix::errno::Errno::ENOSPC => {
                 let _ = writeln!(stderr(), "\nError in handle_input: ALSA MIDI input buffer overrun!\n");
                 continue;
             },
-            Err(ref e) if e.errno() == Some(self::nix::errno::Errno::EAGAIN) => {
+            Err(ref e) if e.errno() == alsa::nix::errno::Errno::EAGAIN => {
                 let _ = writeln!(stderr(), "\nError in handle_input: no input event from ALSA MIDI input buffer!\n");
                 continue;
             },


### PR DESCRIPTION
Since nix that is dependency crate is old, midir cannot build for riscv64gc.
riscv64gc support is added by nix 0.18. So I would like to update alsa to 0.5.0