### PR TITLE
Fix ios compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ alsa = "0.6.0"
 libc = "0.2.21"
 
 [target.'cfg(target_os = "ios")'.dependencies]
-coremidi = "0.4.0"
+coremidi = "0.6.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 coremidi = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,9 @@ libc = { version = "0.2.21", optional = true }
 alsa = "0.6.0"
 libc = "0.2.21"
 
+[target.'cfg(target_os = "ios")'.dependencies]
+coremidi = "0.4.0"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 coremidi = "0.6.0"
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3,20 +3,37 @@
 // TODO: improve feature selection (make sure that there is always exactly one implementation, or enable dynamic backend selection)
 // TODO: allow to disable build dependency on ALSA
 
-#[cfg(all(target_os="windows", not(feature = "winrt")))] mod winmm;
-#[cfg(all(target_os="windows", not(feature = "winrt")))] pub use self::winmm::*;
+#[cfg(all(target_os = "windows", not(feature = "winrt")))]
+mod winmm;
+#[cfg(all(target_os = "windows", not(feature = "winrt")))]
+pub use self::winmm::*;
 
-#[cfg(all(target_os="windows", feature = "winrt"))] mod winrt;
-#[cfg(all(target_os="windows", feature = "winrt"))] pub use self::winrt::*;
+#[cfg(all(target_os = "windows", feature = "winrt"))]
+mod winrt;
+#[cfg(all(target_os = "windows", feature = "winrt"))]
+pub use self::winrt::*;
 
-#[cfg(all(target_os="macos", not(feature = "jack")))] mod coremidi;
-#[cfg(all(target_os="macos", not(feature = "jack")))] pub use self::coremidi::*;
+#[cfg(all(target_os = "macos", not(feature = "jack")))]
+mod coremidi;
+#[cfg(all(target_os = "macos", not(feature = "jack")))]
+pub use self::coremidi::*;
 
-#[cfg(all(target_os="linux", not(feature = "jack")))] mod alsa;
-#[cfg(all(target_os="linux", not(feature = "jack")))] pub use self::alsa::*;
+#[cfg(all(target_os = "ios", not(feature = "jack")))]
+mod coremidi;
+#[cfg(all(target_os = "ios", not(feature = "jack")))]
+pub use self::coremidi::*;
 
-#[cfg(all(feature = "jack", not(target_os="windows")))] mod jack;
-#[cfg(all(feature = "jack", not(target_os="windows")))] pub use self::jack::*;
+#[cfg(all(target_os = "linux", not(feature = "jack")))]
+mod alsa;
+#[cfg(all(target_os = "linux", not(feature = "jack")))]
+pub use self::alsa::*;
 
-#[cfg(target_arch="wasm32")] mod webmidi;
-#[cfg(target_arch="wasm32")] pub use self::webmidi::*;
+#[cfg(all(feature = "jack", not(target_os = "windows")))]
+mod jack;
+#[cfg(all(feature = "jack", not(target_os = "windows")))]
+pub use self::jack::*;
+
+#[cfg(target_arch = "wasm32")]
+mod webmidi;
+#[cfg(target_arch = "wasm32")]
+pub use self::webmidi::*;


### PR DESCRIPTION
Allows `coremidi` back-end to be compiled for iOS targets.

Note: I haven't done any testing that this will work on iOS devices