### PR TITLE
Fix undefined behaviour in the ALSA backend

### DIFF
--- a/src/backend/alsa/mod.rs
+++ b/src/backend/alsa/mod.rs
@@ -588,6 +588,13 @@ impl Drop for MidiOutputConnection {
 fn handle_input<T>(mut data: HandlerData<T>, user_data: &mut T) -> HandlerData<T> {
     use self::alsa::PollDescriptors;
     use self::alsa::seq::Connect;
+    use self::libc::pollfd;
+
+    const INVALID_POLLFD: pollfd = pollfd {
+        fd: -1,
+        events: 0,
+        revents: 0,
+    };
 
     let mut continue_sysex: bool = false;
     
@@ -596,22 +603,17 @@ fn handle_input<T>(mut data: HandlerData<T>, user_data: &mut T) -> HandlerData<T
     let mut buffer = [0; 12];
     
     let mut coder = helpers::EventDecoder::new(false);
-    
-    let mut poll_fds: Box<[self::libc::pollfd]>;
-    {
-        let poll_desc_info = (&data.seq, Some(Direction::Capture));
-        let poll_fd_count = poll_desc_info.count() + 1;
-        let mut vec = Vec::with_capacity(poll_fd_count);
-        unsafe {    
-            vec.set_len(poll_fd_count);
-            poll_fds = vec.into_boxed_slice();
-        }
-        poll_desc_info.fill(&mut poll_fds[1..]).unwrap();
-    }
-    poll_fds[0].fd = data.trigger_rcv_fd;
-    poll_fds[0].events = self::libc::POLLIN;
 
-            
+    let poll_desc_info = (&data.seq, Some(Direction::Capture));
+    let mut poll_fds = vec![INVALID_POLLFD; poll_desc_info.count() + 1];
+    poll_fds[0] = pollfd {
+        fd: data.trigger_rcv_fd,
+        events: self::libc::POLLIN,
+        revents: 0,
+    };
+
+    poll_desc_info.fill(&mut poll_fds[1..]).unwrap();
+
     let mut message = MidiMessage::new();
 
     { // open scope where we can borrow data.seq


### PR DESCRIPTION
Previously, the ALSA backend created a new `Vec<pollfd>`, then immediately called `Vec::set_len`. This exposes uninitialized `pollfd`s, which causes undefined behaviour. This commit fixes this by initializing the `Vec` with invalid, but still initialized, `pollfd`s before filling it. In addition, this commit simplifies the code slightly by removing the usage of `Vec::into_boxed_slice`.

Fixes #110.