### PR TITLE
Update windows crate to 0.37, remove memalloc dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ winrt = [
 
 [dependencies]
 bitflags = "1.2"
-memalloc = "0.1.0"
 jack-sys = { version = "0.2", optional = true }
 libc = { version = "0.2.21", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ coremidi = "0.6.0"
 coremidi = "0.6.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.32.0", features = [
+windows = { version = "0.37", features = [
     "Win32_Foundation",
     "Win32_Media",
     "Win32_Media_Multimedia",

--- a/src/backend/winmm/mod.rs
+++ b/src/backend/winmm/mod.rs
@@ -5,9 +5,9 @@ use std::sync::Mutex;
 use std::io::{Write, stderr};
 use std::thread::sleep;
 use std::time::Duration;
-use memalloc::{allocate, deallocate};
 use std::mem::MaybeUninit;
 use std::ptr::null_mut;
+use std::alloc::{alloc, dealloc, Layout};
 
 use windows::core::PSTR;
 use windows::Win32::Media::{
@@ -223,7 +223,7 @@ impl MidiInput {
         // Allocate and init the sysex buffers.
         for i in 0..MIDIR_SYSEX_BUFFER_COUNT {
             handler_data.sysex_buffer.0[i] = Box::into_raw(Box::new(MIDIHDR {
-                lpData: PSTR(unsafe { allocate(MIDIR_SYSEX_BUFFER_SIZE/*, mem::align_of::<u8>()*/) }),
+                lpData: PSTR(unsafe { alloc(Layout::from_size_align_unchecked(MIDIR_SYSEX_BUFFER_SIZE, 16)) }),
                 dwBufferLength: MIDIR_SYSEX_BUFFER_SIZE as u32,
                 dwBytesRecorded: 0,
                 dwUser: i as DWORD_PTR, // We use the dwUser parameter as buffer indicator

--- a/src/backend/winmm/mod.rs
+++ b/src/backend/winmm/mod.rs
@@ -9,7 +9,7 @@ use memalloc::{allocate, deallocate};
 use std::mem::MaybeUninit;
 use std::ptr::null_mut;
 
-use windows::Win32::Foundation::PSTR;
+use windows::core::PSTR;
 use windows::Win32::Media::{
     MMSYSERR_NOERROR, MMSYSERR_ALLOCATED, MMSYSERR_BADDEVICEID,
 };

--- a/src/backend/winmm/mod.rs
+++ b/src/backend/winmm/mod.rs
@@ -223,7 +223,7 @@ impl MidiInput {
         // Allocate and init the sysex buffers.
         for i in 0..MIDIR_SYSEX_BUFFER_COUNT {
             handler_data.sysex_buffer.0[i] = Box::into_raw(Box::new(MIDIHDR {
-                lpData: PSTR(unsafe { alloc(Layout::from_size_align_unchecked(MIDIR_SYSEX_BUFFER_SIZE, 16)) }),
+                lpData: PSTR(unsafe { alloc(Layout::from_size_align_unchecked(MIDIR_SYSEX_BUFFER_SIZE, 1)) }),
                 dwBufferLength: MIDIR_SYSEX_BUFFER_SIZE as u32,
                 dwBytesRecorded: 0,
                 dwUser: i as DWORD_PTR, // We use the dwUser parameter as buffer indicator
@@ -290,7 +290,7 @@ impl<T> MidiInputConnection<T> {
             let result;
             unsafe {
                 result = midiInUnprepareHeader(*in_handle_lock, self.handler_data.sysex_buffer.0[i], mem::size_of::<MIDIHDR>() as u32);
-                dealloc((*self.handler_data.sysex_buffer.0[i]).lpData.0 as *mut _, Layout::from_size_align_unchecked(MIDIR_SYSEX_BUFFER_SIZE, 16));
+                dealloc((*self.handler_data.sysex_buffer.0[i]).lpData.0 as *mut _, Layout::from_size_align_unchecked(MIDIR_SYSEX_BUFFER_SIZE, 1));
                 // recreate the Box so that it will be dropped/deallocated at the end of this scope
                 let _ = Box::from_raw(self.handler_data.sysex_buffer.0[i]);
             }

--- a/src/backend/winmm/mod.rs
+++ b/src/backend/winmm/mod.rs
@@ -290,7 +290,7 @@ impl<T> MidiInputConnection<T> {
             let result;
             unsafe {
                 result = midiInUnprepareHeader(*in_handle_lock, self.handler_data.sysex_buffer.0[i], mem::size_of::<MIDIHDR>() as u32);
-                deallocate((*self.handler_data.sysex_buffer.0[i]).lpData.0 as *mut _, MIDIR_SYSEX_BUFFER_SIZE/*, mem::align_of::<u8>()*/);
+                dealloc((*self.handler_data.sysex_buffer.0[i]).lpData.0 as *mut _, Layout::from_size_align_unchecked(MIDIR_SYSEX_BUFFER_SIZE, 16));
                 // recreate the Box so that it will be dropped/deallocated at the end of this scope
                 let _ = Box::from_raw(self.handler_data.sysex_buffer.0[i]);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate memalloc;
-
 #[cfg(feature = "jack")]
 #[macro_use] extern crate bitflags;
 


### PR DESCRIPTION
`PSTR` has moved to `core`, that's it.

Yes, the windows crate is [churning a bit much](https://github.com/microsoft/windows-rs/issues/1720), work is underway to make that better but for now, it's a quickly moving upgrade train...