### PR TITLE
[alsa] Fix port listing

### DIFF
--- a/src/backend/alsa/mod.rs
+++ b/src/backend/alsa/mod.rs
@@ -24,7 +24,7 @@ mod helpers {
     pub fn get_ports<F, T>(s: &Seq, capability: PortCap, f: F) -> Vec<T> where F: Fn(PortInfo) -> T {
         ClientIter::new(s).flat_map(|c| PortIter::new(s, c.get_client()))
                           .filter(|p| p.get_type().intersects(PortType::MIDI_GENERIC | PortType::SYNTH | PortType::APPLICATION))
-                          .filter(|p| p.get_capability().intersects(capability))
+                          .filter(|p| p.get_capability().contains(capability))
                           .map(f)
                           .collect()
     }
@@ -33,7 +33,7 @@ mod helpers {
     pub fn get_port_count(s: &Seq, capability: PortCap) -> usize {
         ClientIter::new(s).flat_map(|c| PortIter::new(s, c.get_client()))
                           .filter(|p| p.get_type().intersects(PortType::MIDI_GENERIC | PortType::SYNTH | PortType::APPLICATION))
-                          .filter(|p| p.get_capability().intersects(capability))
+                          .filter(|p| p.get_capability().contains(capability))
                           .count()
     }
 


### PR DESCRIPTION
Searching for either WRITE or SUB_WRITE capabilities causes filling of the ports list with a bunch of ports that are impossible to connect to and always return an error if you try to. I believe that the correct way is to search for both.

Alsa utils do the same:
Search for readable:
https://github.com/alsa-project/alsa-utils/blob/a566f8a0ed6d7ca5fd6ae2d224f3f28654a2f3be/seq/aplaymidi/arecordmidi.c#L685-L689
Search for writable:
https://github.com/alsa-project/alsa-utils/blob/a566f8a0ed6d7ca5fd6ae2d224f3f28654a2f3be/seq/aplaymidi/aplaymidi.c#L832-L836