### PR TITLE
Send MIDI messages on ALSA directly

### DIFF
--- a/src/backend/alsa/mod.rs
+++ b/src/backend/alsa/mod.rs
@@ -560,7 +560,7 @@ impl MidiOutputConnection {
         ev.set_direct();
         
         // Send the event.
-        if self.seq.as_ref().unwrap().event_output(&mut ev).is_err() {
+        if self.seq.as_ref().unwrap().event_output_direct(&mut ev).is_err() {
             return Err(SendError::Other("could not send encoded ALSA message"));
         }
         


### PR DESCRIPTION
ALSA has a default buffer of 16k (on my machine), and sending MIDI messages larger than this requires a call to
snd_seq_set_output_buffer_size(), which is unfortunately not exposed by the alsa crate, first.

Therefore, use event_output_direct instead, which allocates a temporary buffer[1].

1: https://www.alsa-project.org/alsa-doc/alsa-lib/group___seq_event.html#ga63986686b918abeff9902108638c5b2f