### PR TITLE
Fix Jack build on ARM and bump jack-sys version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ winrt = [
 
 [dependencies]
 bitflags = "1.2"
-jack-sys = { version = "0.2", optional = true }
+jack-sys = { version = "0.5", optional = true }
 libc = { version = "0.2.21", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -44,8 +44,8 @@ jobs:
         export PATH="$HOME/.cargo/bin:$PATH"
         echo "##vso[task.setvariable variable=PATH;]$PATH"
       displayName: Install Rust
-  - ${{ if and(startsWith(parameters.name, 'Linux'), not(endsWith(parameters.name, 'WASM'))) }}:
-    # Linux only
+  - ${{ if and(startsWith(parameters.name, 'Linux'), not(endsWith(parameters.name, 'WASM')), not(endsWith(parameters.name, 'ARM'))) }}:
+    # Linux on x86_64 only
     - script: |
         sudo apt-get update && sudo apt-get install -y libasound2-dev libjack-jackd2-dev
       displayName: Install ALSA and Jack dependencies
@@ -61,6 +61,24 @@ jobs:
     - script: |
         rustup target add wasm32-unknown-unknown
       displayName: Add wasm32-unknown-unknown target
+  - ${{ if endsWith(parameters.name, 'ARM') }}:
+    # Linux on ARM only
+    - script: |
+        sudo sed 's/deb\ http:\/\/archive.ubuntu.com\/ubuntu/deb\ [arch=arm64]\ http:\/\/ports.ubuntu.com\/ubuntu-ports/;s/deb\ http:\/\/security.ubuntu.com\/ubuntu/deb\ [arch=arm64]\ http:\/\/ports.ubuntu.com\/ubuntu-ports/' /etc/apt/sources.list > /etc/apt/sources.list.d/arm-sources.list
+        sudo sed -i 's/deb\ /deb\ \[arch=amd64\]\ /' /etc/apt/sources.list
+        sudo dpkg --add-architecture arm64
+        sudo apt-get update
+        sudo apt-get install -y libc6-arm64-cross libc6-dev-arm64-cross gcc-aarch64-linux-gnu
+        export PKG_CONFIG_PATH="/usr/lib/aarch64-linux-gnu/pkgconfig"
+        export PKG_CONFIG_ALLOW_CROSS="true"
+      displayName: Set up ARM cross-compilation environment
+    - script: |
+        rustup target add aarch64-unknown-linux-gnu
+        echo -e "[build]\ntarget = \"aarch64-unknown-linux-gnu\"\n[target.aarch64-unknown-linux-gnu]\nlinker = \"aarch64-linux-gnu-gcc\"">$HOME/.cargo/config
+      displayName: Add aarch64-unknown-linux-gnu target
+    - script: |
+        sudo apt-get install -y libasound2-dev:arm64 libjack-jackd2-dev:arm64
+      displayName: Install ALSA and Jack dependencies
   - ${{ if startsWith(parameters.name, 'Windows') }}:
     # Windows
     - script: |

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -64,10 +64,10 @@ jobs:
   - ${{ if endsWith(parameters.name, 'ARM') }}:
     # Linux on ARM only
     - script: |
-        grep "deb http://azure.archive" /etc/apt/sources.list | sed 's/deb\ http:\/\/azure.archive.ubuntu.com\/ubuntu/deb\ [arch=arm64]\ http:\/\/ports.ubuntu.com\/ubuntu-ports/' > /tmp/arm-sources.list	
+        grep "^deb http://azure.archive" /etc/apt/sources.list | sed 's/deb\ http:\/\/azure.archive.ubuntu.com\/ubuntu/deb\ [arch=arm64]\ http:\/\/ports.ubuntu.com\/ubuntu-ports/' > $HOME/arm-sources.list	
         sudo sed -i 's/deb\ /deb\ \[arch=amd64\]\ /' /etc/apt/sources.list
-        sudo sh -c 'echo -e "\n" >> /etc/apt/sources.list'
-        sudo sh -c 'cat /tmp/arm-sources.list >> /etc/apt/sources.list'
+        sudo sh -c "cat $HOME/arm-sources.list >> /etc/apt/sources.list"
+        rm $HOME/arm-sources.list
         sudo dpkg --add-architecture arm64
         sudo apt-get update
         sudo apt-get install -y libc6-arm64-cross libc6-dev-arm64-cross gcc-aarch64-linux-gnu

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -66,8 +66,8 @@ jobs:
     - script: |
         grep "deb http://azure.archive" /etc/apt/sources.list | sed 's/deb\ http:\/\/azure.archive.ubuntu.com\/ubuntu/deb\ [arch=arm64]\ http:\/\/ports.ubuntu.com\/ubuntu-ports/' > /tmp/arm-sources.list	
         sudo sed -i 's/deb\ /deb\ \[arch=amd64\]\ /' /etc/apt/sources.list
- 	sudo sh -c 'echo -e "\n" >> /etc/apt/sources.list'
- 	sudo sh -c 'cat /tmp/arm-sources.list >> /etc/apt/sources.list'
+        sudo sh -c 'echo -e "\n" >> /etc/apt/sources.list'
+        sudo sh -c 'cat /tmp/arm-sources.list >> /etc/apt/sources.list'
         sudo dpkg --add-architecture arm64
         sudo apt-get update
         sudo apt-get install -y libc6-arm64-cross libc6-dev-arm64-cross gcc-aarch64-linux-gnu

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -71,12 +71,10 @@ jobs:
         sudo dpkg --add-architecture arm64
         sudo apt-get update
         sudo apt-get install -y libc6-arm64-cross libc6-dev-arm64-cross gcc-aarch64-linux-gnu
-        export PKG_CONFIG_PATH="/usr/lib/aarch64-linux-gnu/pkgconfig"
-        export PKG_CONFIG_ALLOW_CROSS="true"
       displayName: Set up ARM cross-compilation environment
     - script: |
         rustup target add aarch64-unknown-linux-gnu
-        echo -e "[build]\ntarget = \"aarch64-unknown-linux-gnu\"\n[target.aarch64-unknown-linux-gnu]\nlinker = \"aarch64-linux-gnu-gcc\"">$HOME/.cargo/config
+        echo -e "[build]\ntarget = \"aarch64-unknown-linux-gnu\"\n[target.aarch64-unknown-linux-gnu]\nlinker = \"aarch64-linux-gnu-gcc\"\n[env]\nPKG_CONFIG_PATH=\"/usr/lib/aarch64-linux-gnu/pkgconfig\"\nPKG_CONFIG_ALLOW_CROSS=\"true\"">$HOME/.cargo/config
       displayName: Add aarch64-unknown-linux-gnu target
     - script: |
         sudo apt-get install -y libasound2-dev:arm64 libjack-jackd2-dev:arm64

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -64,7 +64,7 @@ jobs:
   - ${{ if endsWith(parameters.name, 'ARM') }}:
     # Linux on ARM only
     - script: |
-        grep "deb http://azure.archive" | sed 's/deb\ http:\/\/azure.archive.ubuntu.com\/ubuntu/deb\ [arch=arm64]\ http:\/\/ports.ubuntu.com\/ubuntu-ports/' > /tmp/arm-sources.list	
+        grep "deb http://azure.archive" /etc/apt/sources.list | sed 's/deb\ http:\/\/azure.archive.ubuntu.com\/ubuntu/deb\ [arch=arm64]\ http:\/\/ports.ubuntu.com\/ubuntu-ports/' > /tmp/arm-sources.list	
         sudo sed -i 's/deb\ /deb\ \[arch=amd64\]\ /' /etc/apt/sources.list
  	sudo sh -c 'echo -e "\n" >> /etc/apt/sources.list'
  	sudo sh -c 'cat /tmp/arm-sources.list >> /etc/apt/sources.list'

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -64,8 +64,10 @@ jobs:
   - ${{ if endsWith(parameters.name, 'ARM') }}:
     # Linux on ARM only
     - script: |
-        sudo sed 's/deb\ http:\/\/archive.ubuntu.com\/ubuntu/deb\ [arch=arm64]\ http:\/\/ports.ubuntu.com\/ubuntu-ports/;s/deb\ http:\/\/security.ubuntu.com\/ubuntu/deb\ [arch=arm64]\ http:\/\/ports.ubuntu.com\/ubuntu-ports/' /etc/apt/sources.list > /etc/apt/sources.list.d/arm-sources.list
+        grep "deb http://azure.archive" | sed 's/deb\ http:\/\/azure.archive.ubuntu.com\/ubuntu/deb\ [arch=arm64]\ http:\/\/ports.ubuntu.com\/ubuntu-ports/' > /tmp/arm-sources.list	
         sudo sed -i 's/deb\ /deb\ \[arch=amd64\]\ /' /etc/apt/sources.list
+ 	sudo sh -c 'echo -e "\n" >> /etc/apt/sources.list'
+ 	sudo sh -c 'cat /tmp/arm-sources.list >> /etc/apt/sources.list'
         sudo dpkg --add-architecture arm64
         sudo apt-get update
         sudo apt-get install -y libc6-arm64-cross libc6-dev-arm64-cross gcc-aarch64-linux-gnu

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,3 +24,8 @@ jobs:
     name: Linux_WASM
     vmImage: ubuntu-latest
     target: x86_64-unknown-linux-gnu
+- template: azure-pipelines-template.yml
+  parameters:
+    name: Linux_ARM
+    vmImage: ubuntu-latest
+    target: x86_64-unknown-linux-gnu

--- a/src/backend/jack/wrappers.rs
+++ b/src/backend/jack/wrappers.rs
@@ -83,7 +83,7 @@ impl Client {
     }
     
     pub fn get_midi_ports(&self, flags: PortFlags) -> PortInfos {
-        let ports_ptr = unsafe { jack_get_ports(self.p, ptr::null_mut(), JACK_DEFAULT_MIDI_TYPE.as_ptr() as *const u8, flags.bits() as u64) };
+        let ports_ptr = unsafe { jack_get_ports(self.p, ptr::null_mut(), JACK_DEFAULT_MIDI_TYPE.as_ptr() as *const _, flags.bits() as u64) };
         let slice = if ports_ptr.is_null() {
             &[]
         } else {
@@ -97,7 +97,7 @@ impl Client {
     
     pub fn register_midi_port(&mut self, name: &str, flags: PortFlags) -> Result<MidiPort, ()> {
         let c_name = CString::new(name).ok().expect("port name must not contain null bytes");
-        let result = unsafe { jack_port_register(self.p, c_name.as_ptr(), JACK_DEFAULT_MIDI_TYPE.as_ptr() as *const u8, flags.bits() as u64, 0) };
+        let result = unsafe { jack_port_register(self.p, c_name.as_ptr(), JACK_DEFAULT_MIDI_TYPE.as_ptr() as *const _, flags.bits() as u64, 0) };
         if result.is_null() {
             Err(())
         } else {
@@ -144,8 +144,14 @@ impl Drop for Client {
     }
 }
 
+#[cfg(not(target_arch = "aarch64"))]
+type PortInfo = i8;
+
+#[cfg(target_arch = "aarch64")]
+type PortInfo = u8;
+
 pub struct PortInfos<'a> {
-    p: &'a[*const u8],
+    p: &'a[*const PortInfo],
 }
 
 unsafe impl<'a> Send for PortInfos<'a> {}
@@ -234,12 +240,12 @@ impl Ringbuffer {
     }
     
     pub fn read(&mut self, destination: *mut u8, count: usize) -> usize {
-        let bytes_read = unsafe { jack_ringbuffer_read(self.p, destination as *mut u8, count as size_t) };
+        let bytes_read = unsafe { jack_ringbuffer_read(self.p, destination as *mut _, count as size_t) };
         bytes_read as usize 
     }
     
     pub fn write(&mut self, source: &[u8]) -> usize {
-        unsafe { jack_ringbuffer_write(self.p, source.as_ptr() as *const u8, source.len() as size_t) as usize }
+        unsafe { jack_ringbuffer_write(self.p, source.as_ptr() as *const _, source.len() as size_t) as usize }
     }
 }
 

--- a/src/backend/jack/wrappers.rs
+++ b/src/backend/jack/wrappers.rs
@@ -83,7 +83,7 @@ impl Client {
     }
     
     pub fn get_midi_ports(&self, flags: PortFlags) -> PortInfos {
-        let ports_ptr = unsafe { jack_get_ports(self.p, ptr::null_mut(), JACK_DEFAULT_MIDI_TYPE.as_ptr() as *const _, flags.bits() as u64) };
+        let ports_ptr = unsafe { jack_get_ports(self.p, ptr::null_mut(), JACK_DEFAULT_MIDI_TYPE.as_ptr() as *const _, flags.bits() as _) };
         let slice = if ports_ptr.is_null() {
             &[]
         } else {
@@ -97,7 +97,7 @@ impl Client {
     
     pub fn register_midi_port(&mut self, name: &str, flags: PortFlags) -> Result<MidiPort, ()> {
         let c_name = CString::new(name).ok().expect("port name must not contain null bytes");
-        let result = unsafe { jack_port_register(self.p, c_name.as_ptr(), JACK_DEFAULT_MIDI_TYPE.as_ptr() as *const _, flags.bits() as u64, 0) };
+        let result = unsafe { jack_port_register(self.p, c_name.as_ptr(), JACK_DEFAULT_MIDI_TYPE.as_ptr() as *const _, flags.bits() as _, 0) };
         if result.is_null() {
             Err(())
         } else {
@@ -144,10 +144,10 @@ impl Drop for Client {
     }
 }
 
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(not(any(target_arch = "aarch64", target_arch = "arm")))]
 type PortInfo = i8;
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
 type PortInfo = u8;
 
 pub struct PortInfos<'a> {

--- a/src/backend/jack/wrappers.rs
+++ b/src/backend/jack/wrappers.rs
@@ -83,7 +83,7 @@ impl Client {
     }
     
     pub fn get_midi_ports(&self, flags: PortFlags) -> PortInfos {
-        let ports_ptr = unsafe { jack_get_ports(self.p, ptr::null_mut(), JACK_DEFAULT_MIDI_TYPE.as_ptr() as *const i8, flags.bits() as u64) };
+        let ports_ptr = unsafe { jack_get_ports(self.p, ptr::null_mut(), JACK_DEFAULT_MIDI_TYPE.as_ptr() as *const u8, flags.bits() as u64) };
         let slice = if ports_ptr.is_null() {
             &[]
         } else {
@@ -97,7 +97,7 @@ impl Client {
     
     pub fn register_midi_port(&mut self, name: &str, flags: PortFlags) -> Result<MidiPort, ()> {
         let c_name = CString::new(name).ok().expect("port name must not contain null bytes");
-        let result = unsafe { jack_port_register(self.p, c_name.as_ptr(), JACK_DEFAULT_MIDI_TYPE.as_ptr() as *const i8, flags.bits() as u64, 0) };
+        let result = unsafe { jack_port_register(self.p, c_name.as_ptr(), JACK_DEFAULT_MIDI_TYPE.as_ptr() as *const u8, flags.bits() as u64, 0) };
         if result.is_null() {
             Err(())
         } else {
@@ -145,7 +145,7 @@ impl Drop for Client {
 }
 
 pub struct PortInfos<'a> {
-    p: &'a[*const i8],
+    p: &'a[*const u8],
 }
 
 unsafe impl<'a> Send for PortInfos<'a> {}
@@ -234,12 +234,12 @@ impl Ringbuffer {
     }
     
     pub fn read(&mut self, destination: *mut u8, count: usize) -> usize {
-        let bytes_read = unsafe { jack_ringbuffer_read(self.p, destination as *mut i8, count as size_t) };
+        let bytes_read = unsafe { jack_ringbuffer_read(self.p, destination as *mut u8, count as size_t) };
         bytes_read as usize 
     }
     
     pub fn write(&mut self, source: &[u8]) -> usize {
-        unsafe { jack_ringbuffer_write(self.p, source.as_ptr() as *const i8, source.len() as size_t) as usize }
+        unsafe { jack_ringbuffer_write(self.p, source.as_ptr() as *const u8, source.len() as size_t) as usize }
     }
 }
 


### PR DESCRIPTION
This PR resolves build issues with the `jack` feature enabled and bumps the `jack-sys` version to the latest one. Tested on Arch Linux and Ubuntu 22.04.