### PR TITLE
Replace `windows` with `windows-sys`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,37 +18,43 @@ default = []
 avoid_timestamping = []
 coremidi_send_timestamped = []
 jack = ["jack-sys", "libc"]
-winrt = [
-    "windows/Foundation",
-    "windows/Foundation_Collections",
-    "windows/Devices_Midi",
-    "windows/Devices_Enumeration",
-    "windows/Storage_Streams",
-    "windows/Win32_System_WinRT",
-]
+winrt = ["windows"]
 
 [dependencies]
-bitflags = "1.2"
+bitflags = "2.4"
 jack-sys = { version = "0.5", optional = true }
 libc = { version = "0.2.21", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-alsa = "0.7.0"
+alsa = "0.8.0"
 libc = "0.2.21"
 
 [target.'cfg(target_os = "ios")'.dependencies]
-coremidi = "0.6.0"
+coremidi = "0.8.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-coremidi = "0.6.0"
+coremidi = "0.8.0"
 
-[target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.43", features = [
+[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
+version = "0.52"
+features = [
     "Win32_Foundation",
     "Win32_Media",
     "Win32_Media_Multimedia",
     "Win32_Media_Audio",
-] }
+]
+
+[target.'cfg(target_os = "windows")'.dependencies.windows]
+version = "0.52"
+optional = true
+features = [
+    "Foundation",
+    "Foundation_Collections",
+    "Devices_Midi",
+    "Devices_Enumeration",
+    "Storage_Streams",
+    "Win32_System_WinRT",
+]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"
@@ -69,4 +75,4 @@ web-sys = { version = "0.3", features = [
 ] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = "0.2"
+wasm-bindgen-test = "0.3"

--- a/src/backend/winmm/handler.rs
+++ b/src/backend/winmm/handler.rs
@@ -1,8 +1,8 @@
 use std::io::{stderr, Write};
 use std::{mem, slice};
 
-use windows::Win32::Media::Audio::{midiInAddBuffer, HMIDIIN, MIDIHDR};
-use windows::Win32::Media::{MMSYSERR_NOERROR, MM_MIM_DATA, MM_MIM_LONGDATA, MM_MIM_LONGERROR};
+use windows_sys::Win32::Media::Audio::{midiInAddBuffer, HMIDIIN, MIDIHDR};
+use windows_sys::Win32::Media::{MMSYSERR_NOERROR, MM_MIM_DATA, MM_MIM_LONGDATA, MM_MIM_LONGERROR};
 
 use crate::Ignore;
 
@@ -74,7 +74,7 @@ pub extern "system" fn handle_input<T>(
         if !data.ignore_flags.contains(Ignore::Sysex) && input_status != MM_MIM_LONGERROR {
             // Sysex message and we're not ignoring it
             let bytes: &[u8] =
-                unsafe { slice::from_raw_parts(sysex.lpData.0, sysex.dwBytesRecorded as usize) };
+                unsafe { slice::from_raw_parts(sysex.lpData, sysex.dwBytesRecorded as usize) };
             data.message.bytes.extend_from_slice(bytes);
             // TODO: If sysex messages are longer than MIDIR_SYSEX_BUFFER_SIZE, they
             //       are split in chunks. We could reassemble a single message.

--- a/src/backend/winmm/mod.rs
+++ b/src/backend/winmm/mod.rs
@@ -9,8 +9,6 @@ use std::thread::sleep;
 use std::time::Duration;
 use std::{mem, ptr, slice};
 
-use windows::Win32::Media::Multimedia::{DRV_QUERYDEVICEINTERFACE, DRV_QUERYDEVICEINTERFACESIZE};
-use windows::Win32::Media::{MMSYSERR_ALLOCATED, MMSYSERR_BADDEVICEID, MMSYSERR_NOERROR};
 use windows_sys::Win32::Media::Audio::{
     midiInAddBuffer, midiInClose, midiInGetDevCapsW, midiInGetNumDevs, midiInMessage, midiInOpen,
     midiInPrepareHeader, midiInReset, midiInStart, midiInStop, midiInUnprepareHeader, midiOutClose,

--- a/src/backend/winrt/mod.rs
+++ b/src/backend/winrt/mod.rs
@@ -161,8 +161,7 @@ pub struct MidiInputConnection<T> {
 impl<T> MidiInputConnection<T> {
     pub fn close(self) -> (MidiInput, T) {
         let _ = self.port.0.RemoveMessageReceived(self.event_token);
-        let closable: IClosable = self.port.0.try_into().unwrap();
-        let _ = closable.Close();
+        let _ = self.port.0.Close();
         let device_selector = MidiInPort::GetDeviceSelector().expect("GetDeviceSelector failed"); // probably won't ever fail here, because it worked previously
         let mut handler_data_locked = self.handler_data.lock().unwrap();
         (
@@ -263,8 +262,7 @@ unsafe impl Send for MidiOutputConnection {}
 
 impl MidiOutputConnection {
     pub fn close(self) -> MidiOutput {
-        let closable: IClosable = self.port.try_into().unwrap();
-        let _ = closable.Close();
+        let _ = self.port.Close();
         let device_selector = MidiOutPort::GetDeviceSelector().expect("GetDeviceSelector failed"); // probably won't ever fail here, because it worked previously
         MidiOutput {
             selector: device_selector,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,12 @@
 #[macro_use]
 extern crate bitflags;
 
+#[cfg(all(target_os = "windows", feature = "winrt"))]
+extern crate windows;
+
+#[cfg(all(target_os = "windows", not(feature = "winrt")))]
+extern crate windows_sys;
+
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// An enum that is used to specify what kind of MIDI messages should


### PR DESCRIPTION
...when not using `winrt` feature.

The compile time cost of `windows` is not too bad compared to `windows-sys` for the features used by this crate, ~4.4s vs ~0.8s, and unfortunately due to how optional crates and cfg works in cargo we now add the cost of `windows-sys` when the `winrt` feature is enabled even though it is not used, but I think the inverse of compiling the heavier `windows` crate when it's not needed is worse, but it is a tradeoff.