### PR TITLE
MidiInput: Add missing trait bound for callback data param

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -106,7 +106,7 @@ impl MidiInput {
     ///
     /// An error will be returned when the port is no longer valid
     /// (e.g. the respective device has been disconnected).
-    pub fn connect<F, T: Send>(
+    pub fn connect<F, T>(
         self, port: &MidiInputPort, port_name: &str, callback: F, data: T
     ) -> Result<MidiInputConnection<T>, ConnectError<MidiInput>>
         where F: FnMut(u64, &[u8], &mut T) + Send + 'static, T: Send {

--- a/src/common.rs
+++ b/src/common.rs
@@ -109,7 +109,7 @@ impl MidiInput {
     pub fn connect<F, T: Send>(
         self, port: &MidiInputPort, port_name: &str, callback: F, data: T
     ) -> Result<MidiInputConnection<T>, ConnectError<MidiInput>>
-        where F: FnMut(u64, &[u8], &mut T) + Send + 'static {
+        where F: FnMut(u64, &[u8], &mut T) + Send + 'static, T: Send {
         match self.imp.connect(&port.imp, port_name, callback, data) {
             Ok(imp) => Ok(MidiInputConnection { imp: imp }),
             Err(imp) => {


### PR DESCRIPTION
Build (native on Fedora 38) suddenly started to fail. I have no clue why.

```
   Compiling midir v0.9.1
error[E0277]: `T` cannot be sent between threads safely
   --> /home/uk/.cargo/registry/src/index.crates.io-6f17d22bba15001f/midir-0.9.1/src/common.rs:113:64
    |
113 |         match self.imp.connect(&port.imp, port_name, callback, data) {
    |                        -------                                 ^^^^ `T` cannot be sent between threads safely
    |                        |
    |                        required by a bound introduced by this call
    |
note: required by a bound in `backend::alsa::MidiInput::connect`
   --> /home/uk/.cargo/registry/src/index.crates.io-6f17d22bba15001f/midir-0.9.1/src/backend/alsa/mod.rs:236:26
    |
236 |     pub fn connect<F, T: Send>(
    |                          ^^^^ required by this bound in `MidiInput::connect`
help: consider further restricting type parameter `T`
    |
112 |         where F: FnMut(u64, &[u8], &mut T) + Send + 'static, T: std::marker::Send {
    |                                                            ++++++++++++++++++++++

For more information about this error, try `rustc --explain E0277`.
error: could not compile `midir` (lib) due to previous error
```

~~**_This fix is a breaking API change!_**~~ Not. Only a different way of writing trait bounds. See the comments below. However the compiler seems to stumble over a mixed specification of trait bounds under yet unknown circumstances.