### PR TITLE
Fix clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 keywords = ["midi", "audio", "music", "sound"]
 categories = ["multimedia::audio", "api-bindings"]
 license = "MIT"
+edition = "2021"
 
 [features]
 default = []

--- a/examples/browser/Cargo.toml
+++ b/examples/browser/Cargo.toml
@@ -2,6 +2,7 @@
 name = "midir_browser_example"
 version = "0.0.0"
 publish = false
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/examples/browser/src/lib.rs
+++ b/examples/browser/src/lib.rs
@@ -24,7 +24,7 @@ pub fn start() {
     let token_outer = Arc::new(Mutex::new(None));
     let token = token_outer.clone();
     let closure: Closure<dyn FnMut()> = Closure::wrap(Box::new(move || {
-        if run().unwrap() == true {
+        if run().unwrap() {
             if let Some(token) = *token.lock().unwrap() {
                 web_sys::window().unwrap().clear_interval_with_handle(token);
             }

--- a/examples/browser/src/lib.rs
+++ b/examples/browser/src/lib.rs
@@ -1,9 +1,3 @@
-extern crate console_error_panic_hook;
-extern crate js_sys;
-extern crate midir;
-extern crate wasm_bindgen;
-extern crate web_sys;
-
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
@@ -74,8 +68,8 @@ fn run() -> Result<bool, Box<dyn Error>> {
             loop {
                 if let Ok(Some(port_str)) = window.prompt_with_message_and_default(&msg, "0") {
                     if let Ok(port_int) = port_str.parse::<usize>() {
-                        if let Some(port) = &ports.get(port_int) {
-                            break port.clone();
+                        if let Some(port) = ports.get(port_int) {
+                            break port;
                         }
                     }
                 }

--- a/examples/test_forward.rs
+++ b/examples/test_forward.rs
@@ -6,7 +6,7 @@ use midir::{Ignore, MidiIO, MidiInput, MidiOutput};
 fn main() {
     match run() {
         Ok(_) => (),
-        Err(err) => println!("Error: {}", err),
+        Err(err) => println!("Error: {err}"),
     }
 }
 
@@ -40,8 +40,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     )?;
 
     println!(
-        "Connections open, forwarding from '{}' to '{}' (press enter to exit) ...",
-        in_port_name, out_port_name
+        "Connections open, forwarding from '{in_port_name}' to '{out_port_name}' (press enter to exit) ...",
     );
 
     let mut input = String::new();
@@ -52,12 +51,12 @@ fn run() -> Result<(), Box<dyn Error>> {
 }
 
 fn select_port<T: MidiIO>(midi_io: &T, descr: &str) -> Result<T::Port, Box<dyn Error>> {
-    println!("Available {} ports:", descr);
+    println!("Available {descr} ports:");
     let midi_ports = midi_io.ports();
     for (i, p) in midi_ports.iter().enumerate() {
         println!("{}: {}", i, midi_io.port_name(p)?);
     }
-    print!("Please select {} port: ", descr);
+    print!("Please select {descr} port: ");
     stdout().flush()?;
     let mut input = String::new();
     stdin().read_line(&mut input)?;

--- a/examples/test_forward.rs
+++ b/examples/test_forward.rs
@@ -1,5 +1,3 @@
-extern crate midir;
-
 use std::error::Error;
 use std::io::{stdin, stdout, Write};
 

--- a/examples/test_list_ports.rs
+++ b/examples/test_list_ports.rs
@@ -6,7 +6,7 @@ use midir::{Ignore, MidiInput, MidiOutput};
 fn main() {
     match run() {
         Ok(_) => (),
-        Err(err) => println!("Error: {}", err),
+        Err(err) => println!("Error: {err}"),
     }
 }
 

--- a/examples/test_list_ports.rs
+++ b/examples/test_list_ports.rs
@@ -1,4 +1,3 @@
-
 use std::error::Error;
 use std::io::{stdin, stdout, Write};
 

--- a/examples/test_list_ports.rs
+++ b/examples/test_list_ports.rs
@@ -1,4 +1,3 @@
-extern crate midir;
 
 use std::error::Error;
 use std::io::{stdin, stdout, Write};

--- a/examples/test_play.rs
+++ b/examples/test_play.rs
@@ -1,5 +1,3 @@
-extern crate midir;
-
 use std::error::Error;
 use std::io::{stdin, stdout, Write};
 use std::thread::sleep;

--- a/examples/test_play.rs
+++ b/examples/test_play.rs
@@ -8,7 +8,7 @@ use midir::{MidiOutput, MidiOutputPort};
 fn main() {
     match run() {
         Ok(_) => (),
-        Err(err) => println!("Error: {}", err),
+        Err(err) => println!("Error: {err}"),
     }
 }
 

--- a/examples/test_read_input.rs
+++ b/examples/test_read_input.rs
@@ -1,4 +1,3 @@
-
 use std::error::Error;
 use std::io::{stdin, stdout, Write};
 

--- a/examples/test_read_input.rs
+++ b/examples/test_read_input.rs
@@ -6,7 +6,7 @@ use midir::{Ignore, MidiInput};
 fn main() {
     match run() {
         Ok(_) => (),
-        Err(err) => println!("Error: {}", err),
+        Err(err) => println!("Error: {err}"),
     }
 }
 
@@ -55,10 +55,7 @@ fn run() -> Result<(), Box<dyn Error>> {
         (),
     )?;
 
-    println!(
-        "Connection open, reading input from '{}' (press enter to exit) ...",
-        in_port_name
-    );
+    println!("Connection open, reading input from '{in_port_name}' (press enter to exit) ...");
 
     input.clear();
     stdin().read_line(&mut input)?; // wait for next enter key press

--- a/examples/test_read_input.rs
+++ b/examples/test_read_input.rs
@@ -1,4 +1,3 @@
-extern crate midir;
 
 use std::error::Error;
 use std::io::{stdin, stdout, Write};

--- a/examples/test_reuse.rs
+++ b/examples/test_reuse.rs
@@ -8,7 +8,7 @@ use midir::{Ignore, MidiInput, MidiOutput};
 fn main() {
     match run() {
         Ok(_) => (),
-        Err(err) => println!("Error: {}", err),
+        Err(err) => println!("Error: {err}"),
     }
 }
 
@@ -70,18 +70,17 @@ fn run() -> Result<(), Box<dyn Error>> {
             stdin().read_line(&mut input)?;
             if input.trim() == "q" {
                 break;
-            } else {
-                conn_out.send(&[144, 60, 1])?;
-                sleep(Duration::from_millis(200));
-                conn_out.send(&[144, 60, 0])?;
             }
+            conn_out.send(&[144, 60, 1])?;
+            sleep(Duration::from_millis(200));
+            conn_out.send(&[144, 60, 0])?;
         }
         println!("Closing connections");
         let (midi_in_, log_all_bytes) = conn_in.close();
         midi_in = midi_in_;
         midi_out = conn_out.close();
         println!("Connections closed");
-        println!("Received bytes: {:?}", log_all_bytes);
+        println!("Received bytes: {log_all_bytes:?}");
     }
     Ok(())
 }

--- a/examples/test_reuse.rs
+++ b/examples/test_reuse.rs
@@ -1,5 +1,3 @@
-extern crate midir;
-
 use std::error::Error;
 use std::io::{stdin, stdout, Write};
 use std::thread::sleep;

--- a/examples/test_sysex.rs
+++ b/examples/test_sysex.rs
@@ -1,5 +1,3 @@
-extern crate midir;
-
 fn main() {
     match example::run() {
         Ok(_) => (),

--- a/examples/test_sysex.rs
+++ b/examples/test_sysex.rs
@@ -53,7 +53,7 @@ mod example {
         println!("Sending large SysEx message ...");
         let mut v = Vec::with_capacity(LARGE_SYSEX_SIZE);
         v.push(0xF0u8);
-        v.extend([0].iter().cycle().take(LARGE_SYSEX_SIZE - 2));
+        v.extend(std::iter::repeat(0).take(LARGE_SYSEX_SIZE - 2));
         v.push(0xF7u8);
         assert_eq!(v.len(), LARGE_SYSEX_SIZE);
         conn_out.send(&v)?;

--- a/examples/test_sysex.rs
+++ b/examples/test_sysex.rs
@@ -39,9 +39,9 @@ mod example {
         let new_port = out_ports.last().unwrap();
         println!(
             "Connecting to port '{}' ...",
-            midi_out.port_name(&new_port).unwrap()
+            midi_out.port_name(new_port).unwrap()
         );
-        let mut conn_out = midi_out.connect(&new_port, "midir-test")?;
+        let mut conn_out = midi_out.connect(new_port, "midir-test")?;
         println!("Starting to send messages ...");
         //sleep(Duration::from_millis(2000));
         println!("Sending NoteOn message");
@@ -53,9 +53,7 @@ mod example {
         println!("Sending large SysEx message ...");
         let mut v = Vec::with_capacity(LARGE_SYSEX_SIZE);
         v.push(0xF0u8);
-        for _ in 1..LARGE_SYSEX_SIZE - 1 {
-            v.push(0u8);
-        }
+        v.extend([0].iter().cycle().take(LARGE_SYSEX_SIZE - 2));
         v.push(0xF7u8);
         assert_eq!(v.len(), LARGE_SYSEX_SIZE);
         conn_out.send(&v)?;
@@ -72,7 +70,7 @@ mod example {
         println!("Closing output ...");
         conn_out.close();
         println!("Closing virtual input ...");
-        conn_in.close().0;
+        conn_in.close();
         Ok(())
     }
 }

--- a/examples/test_sysex.rs
+++ b/examples/test_sysex.rs
@@ -1,7 +1,7 @@
 fn main() {
     match example::run() {
         Ok(_) => (),
-        Err(err) => println!("Error: {}", err),
+        Err(err) => println!("Error: {err}"),
     }
 }
 

--- a/src/backend/coremidi/mod.rs
+++ b/src/backend/coremidi/mod.rs
@@ -1,12 +1,9 @@
-extern crate coremidi;
-
 use std::sync::{Arc, Mutex};
 
-use errors::*;
-use Ignore;
-use MidiMessage;
+use crate::errors::*;
+use crate::{Ignore, MidiMessage};
 
-use self::coremidi::*;
+use coremidi::*;
 
 mod external {
     #[link(name = "CoreAudio", kind = "framework")]
@@ -48,10 +45,10 @@ impl MidiInput {
         }
     }
 
-    pub(crate) fn ports_internal(&self) -> Vec<::common::MidiInputPort> {
+    pub(crate) fn ports_internal(&self) -> Vec<crate::common::MidiInputPort> {
         Sources
             .into_iter()
-            .map(|s| ::common::MidiInputPort {
+            .map(|s| crate::common::MidiInputPort {
                 imp: MidiInputPort {
                     source: Arc::new(s),
                 },
@@ -314,10 +311,10 @@ impl MidiOutput {
         }
     }
 
-    pub(crate) fn ports_internal(&self) -> Vec<::common::MidiOutputPort> {
+    pub(crate) fn ports_internal(&self) -> Vec<crate::common::MidiOutputPort> {
         Destinations
             .into_iter()
-            .map(|d| ::common::MidiOutputPort {
+            .map(|d| crate::common::MidiOutputPort {
                 imp: MidiOutputPort { dest: Arc::new(d) },
             })
             .collect()

--- a/src/backend/coremidi/mod.rs
+++ b/src/backend/coremidi/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::{Arc, Mutex};
 
+use crate::backend::Callback;
 use crate::errors::*;
 use crate::{Ignore, MidiMessage};
 
@@ -279,7 +280,7 @@ struct HandlerData<T> {
     message: MidiMessage,
     ignore_flags: Ignore,
     continue_sysex: bool,
-    callback: Box<dyn FnMut(u64, &[u8], &mut T) + Send>,
+    callback: Callback<T>,
     user_data: Option<T>,
 }
 

--- a/src/backend/jack/mod.rs
+++ b/src/backend/jack/mod.rs
@@ -1,8 +1,5 @@
-extern crate jack_sys;
-extern crate libc;
-
-use self::jack_sys::jack_nframes_t;
-use self::libc::c_void;
+use jack_sys::jack_nframes_t;
+use libc::c_void;
 
 use std::ffi::CString;
 use std::{mem, slice};
@@ -10,8 +7,8 @@ use std::{mem, slice};
 mod wrappers;
 use self::wrappers::*;
 
-use errors::*;
-use {Ignore, MidiMessage};
+use crate::errors::*;
+use crate::{Ignore, MidiMessage};
 
 const OUTPUT_RINGBUFFER_SIZE: usize = 16384;
 
@@ -56,7 +53,7 @@ impl MidiInput {
         self.ignore_flags = flags;
     }
 
-    pub(crate) fn ports_internal(&self) -> Vec<::common::MidiInputPort> {
+    pub(crate) fn ports_internal(&self) -> Vec<crate::common::MidiInputPort> {
         let ports = self
             .client
             .as_ref()
@@ -64,7 +61,7 @@ impl MidiInput {
             .get_midi_ports(PortFlags::PortIsOutput);
         let mut result = Vec::with_capacity(ports.count());
         for i in 0..ports.count() {
-            result.push(::common::MidiInputPort {
+            result.push(crate::common::MidiInputPort {
                 imp: MidiInputPort {
                     name: ports.get_c_name(i).into(),
                 },
@@ -280,7 +277,7 @@ impl MidiOutput {
         })
     }
 
-    pub(crate) fn ports_internal(&self) -> Vec<::common::MidiOutputPort> {
+    pub(crate) fn ports_internal(&self) -> Vec<crate::common::MidiOutputPort> {
         let ports = self
             .client
             .as_ref()
@@ -288,7 +285,7 @@ impl MidiOutput {
             .get_midi_ports(PortFlags::PortIsInput);
         let mut result = Vec::with_capacity(ports.count());
         for i in 0..ports.count() {
-            result.push(::common::MidiOutputPort {
+            result.push(crate::common::MidiOutputPort {
                 imp: MidiOutputPort {
                     name: ports.get_c_name(i).into(),
                 },

--- a/src/backend/jack/wrappers.rs
+++ b/src/backend/jack/wrappers.rs
@@ -52,9 +52,7 @@ impl Client {
     }
 
     pub fn open(name: &str, options: JackOpenOptions) -> Result<Client, ()> {
-        let c_name = CString::new(name)
-            .ok()
-            .expect("client name must not contain null bytes");
+        let c_name = CString::new(name).expect("client name must not contain null bytes");
         let result = unsafe { jack_client_open(c_name.as_ptr(), options.bits(), ptr::null_mut()) };
         if result.is_null() {
             Err(())
@@ -86,9 +84,7 @@ impl Client {
     }
 
     pub fn register_midi_port(&mut self, name: &str, flags: PortFlags) -> Result<MidiPort, ()> {
-        let c_name = CString::new(name)
-            .ok()
-            .expect("port name must not contain null bytes");
+        let c_name = CString::new(name).expect("port name must not contain null bytes");
         let result = unsafe {
             jack_port_register(
                 self.p,
@@ -172,15 +168,13 @@ impl<'a> Index<usize> for PortInfos<'a> {
 
     fn index(&self, index: usize) -> &Self::Output {
         let slice = self.get_c_name(index).to_bytes();
-        str::from_utf8(slice)
-            .ok()
-            .expect("Error converting port name to UTF8")
+        str::from_utf8(slice).expect("Error converting port name to UTF8")
     }
 }
 
 impl<'a> Drop for PortInfos<'a> {
     fn drop(&mut self) {
-        if self.p.len() > 0 {
+        if !self.p.is_empty() {
             unsafe { jack_free(self.p.as_ptr() as *mut _) }
         }
     }
@@ -242,19 +236,16 @@ impl Ringbuffer {
     }
 
     pub fn get_read_space(&self) -> usize {
-        unsafe { jack_ringbuffer_read_space(self.p) as usize }
+        unsafe { jack_ringbuffer_read_space(self.p) }
     }
 
     pub fn read(&mut self, destination: *mut u8, count: usize) -> usize {
-        let bytes_read =
-            unsafe { jack_ringbuffer_read(self.p, destination as *mut _, count as size_t) };
-        bytes_read as usize
+        unsafe { jack_ringbuffer_read(self.p, destination as *mut _, count as size_t) }
     }
 
     pub fn write(&mut self, source: &[u8]) -> usize {
         unsafe {
             jack_ringbuffer_write(self.p, source.as_ptr() as *const _, source.len() as size_t)
-                as usize
         }
     }
 }

--- a/src/backend/jack/wrappers.rs
+++ b/src/backend/jack/wrappers.rs
@@ -4,9 +4,9 @@ use std::ffi::{CStr, CString};
 use std::ops::Index;
 use std::{ptr, slice, str};
 
-use super::libc::{c_void, size_t};
+use libc::{c_void, size_t};
 
-use super::jack_sys::{
+use jack_sys::{
     jack_activate, jack_client_close, jack_client_open, jack_client_t, jack_connect,
     jack_deactivate, jack_free, jack_get_ports, jack_get_time, jack_midi_clear_buffer,
     jack_midi_data_t, jack_midi_event_get, jack_midi_event_reserve, jack_midi_event_t,

--- a/src/backend/jack/wrappers.rs
+++ b/src/backend/jack/wrappers.rs
@@ -18,7 +18,7 @@ use jack_sys::{
 
 pub const JACK_DEFAULT_MIDI_TYPE: &[u8] = b"8 bit raw midi\0";
 
-bitflags! {
+bitflags::bitflags! {
     pub struct JackOpenOptions: u32 {
         const NoStartServer = 1;
         const UseExactName = 2;
@@ -27,7 +27,7 @@ bitflags! {
     }
 }
 
-bitflags! {
+bitflags::bitflags! {
     pub struct PortFlags: u32 {
         const PortIsInput = 1;
         const PortIsOutput = 2;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3,6 +3,7 @@
 // TODO: improve feature selection (make sure that there is always exactly one implementation, or enable dynamic backend selection)
 // TODO: allow to disable build dependency on ALSA
 
+#[allow(unused)]
 pub type Callback<T> = Box<dyn FnMut(u64, &[u8], &mut T) + Send>;
 
 #[cfg(all(target_os = "windows", not(feature = "winrt")))]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3,6 +3,8 @@
 // TODO: improve feature selection (make sure that there is always exactly one implementation, or enable dynamic backend selection)
 // TODO: allow to disable build dependency on ALSA
 
+pub type Callback<T> = Box<dyn FnMut(u64, &[u8], &mut T) + Send>;
+
 #[cfg(all(target_os = "windows", not(feature = "winrt")))]
 mod winmm;
 #[cfg(all(target_os = "windows", not(feature = "winrt")))]

--- a/src/backend/webmidi/mod.rs
+++ b/src/backend/webmidi/mod.rs
@@ -4,20 +4,16 @@
 //! * [W3C Editor's Draft](https://webaudio.github.io/web-midi-api/)
 //! * [MDN web docs](https://developer.mozilla.org/en-US/docs/Web/API/MIDIAccess)
 
-extern crate js_sys;
-extern crate wasm_bindgen;
-extern crate web_sys;
-
-use self::js_sys::{Map, Promise, Uint8Array};
-use self::wasm_bindgen::prelude::*;
-use self::wasm_bindgen::JsCast;
-use self::web_sys::{MidiAccess, MidiMessageEvent, MidiOptions};
+use js_sys::{Map, Promise, Uint8Array};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use web_sys::{MidiAccess, MidiMessageEvent, MidiOptions};
 
 use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
 
-use errors::*;
-use Ignore;
+use crate::errors::*;
+use crate::Ignore;
 
 thread_local! {
     static STATIC : RefCell<Static> = RefCell::new(Static::new());
@@ -111,14 +107,14 @@ impl MidiInput {
         })
     }
 
-    pub(crate) fn ports_internal(&self) -> Vec<::common::MidiInputPort> {
+    pub(crate) fn ports_internal(&self) -> Vec<crate::common::MidiInputPort> {
         STATIC.with(|s| {
             let mut v = Vec::new();
             let s = s.borrow();
             if let Some(access) = s.access.as_ref() {
                 let inputs: Map = access.inputs().unchecked_into();
                 inputs.for_each(&mut |value, _| {
-                    v.push(::common::MidiInputPort {
+                    v.push(crate::common::MidiInputPort {
                         imp: MidiInputPort {
                             input: value.dyn_into().unwrap(),
                         },
@@ -235,7 +231,7 @@ impl MidiOutput {
         Ok(MidiOutput {})
     }
 
-    pub(crate) fn ports_internal(&self) -> Vec<::common::MidiOutputPort> {
+    pub(crate) fn ports_internal(&self) -> Vec<crate::common::MidiOutputPort> {
         STATIC.with(|s| {
             let mut v = Vec::new();
             let s = s.borrow();
@@ -244,7 +240,7 @@ impl MidiOutput {
                     .outputs()
                     .unchecked_into::<Map>()
                     .for_each(&mut |value, _| {
-                        v.push(::common::MidiOutputPort {
+                        v.push(crate::common::MidiOutputPort {
                             imp: MidiOutputPort {
                                 output: value.dyn_into().unwrap(),
                             },

--- a/src/backend/winmm/handler.rs
+++ b/src/backend/winmm/handler.rs
@@ -4,10 +4,11 @@ use std::{mem, slice};
 use windows::Win32::Media::Audio::{midiInAddBuffer, HMIDIIN, MIDIHDR};
 use windows::Win32::Media::{MMSYSERR_NOERROR, MM_MIM_DATA, MM_MIM_LONGDATA, MM_MIM_LONGERROR};
 
+use crate::Ignore;
+
 use super::{DWORD, DWORD_PTR, UINT};
 
 use super::HandlerData;
-use Ignore;
 
 pub extern "system" fn handle_input<T>(
     _: HMIDIIN,

--- a/src/backend/winmm/mod.rs
+++ b/src/backend/winmm/mod.rs
@@ -30,8 +30,8 @@ type DWORD = u32;
 #[allow(non_camel_case_types)]
 type DWORD_PTR = usize;
 
-use errors::*;
-use {Ignore, MidiMessage};
+use crate::errors::*;
+use crate::{Ignore, MidiMessage};
 
 mod handler;
 
@@ -187,7 +187,7 @@ impl MidiInput {
         self.ignore_flags = flags;
     }
 
-    pub(crate) fn ports_internal(&self) -> Vec<::common::MidiInputPort> {
+    pub(crate) fn ports_internal(&self) -> Vec<crate::common::MidiInputPort> {
         let count = MidiInputPort::count();
         let mut result = Vec::with_capacity(count as usize);
         for i in 0..count {
@@ -195,7 +195,7 @@ impl MidiInput {
                 Ok(p) => p,
                 Err(_) => continue,
             };
-            result.push(::common::MidiInputPort { imp: port });
+            result.push(crate::common::MidiInputPort { imp: port });
         }
         result
     }
@@ -503,7 +503,7 @@ impl MidiOutput {
         Ok(MidiOutput)
     }
 
-    pub(crate) fn ports_internal(&self) -> Vec<::common::MidiOutputPort> {
+    pub(crate) fn ports_internal(&self) -> Vec<crate::common::MidiOutputPort> {
         let count = MidiOutputPort::count();
         let mut result = Vec::with_capacity(count as usize);
         for i in 0..count {
@@ -511,7 +511,7 @@ impl MidiOutput {
                 Ok(p) => p,
                 Err(_) => continue,
             };
-            result.push(::common::MidiOutputPort { imp: port });
+            result.push(crate::common::MidiOutputPort { imp: port });
         }
         result
     }

--- a/src/backend/winrt/mod.rs
+++ b/src/backend/winrt/mod.rs
@@ -1,14 +1,15 @@
 use std::convert::TryInto;
 use std::sync::{Arc, Mutex};
 
-use crate::errors::*;
+use crate::backend::Callback;
+use crate::errors::{ConnectError, ConnectErrorKind, InitError, PortInfoError, SendError};
 use crate::Ignore;
 
 use windows::core::HSTRING;
 
 use windows::{
     Devices::Enumeration::DeviceInformation,
-    Devices::Midi::*,
+    Devices::Midi::{IMidiOutPort, MidiInPort, MidiMessageReceivedEventArgs, MidiOutPort},
     Foundation::{EventRegistrationToken, IClosable, TypedEventHandler},
     Storage::Streams::{DataReader, DataWriter},
 };
@@ -42,8 +43,8 @@ impl MidiInput {
             .get()
             .expect("FindAllAsyncAqsFilter failed");
         let count = device_collection.Size().expect("Size failed") as usize;
-        let mut result = Vec::with_capacity(count as usize);
-        for device_info in device_collection.into_iter() {
+        let mut result = Vec::with_capacity(count);
+        for device_info in device_collection {
             let device_id = device_info.Id().expect("Id failed");
             result.push(crate::common::MidiInputPort {
                 imp: MidiInputPort { id: device_id },
@@ -139,8 +140,8 @@ impl MidiInput {
 
         Ok(MidiInputConnection {
             port: RtMidiInPort(in_port),
-            event_token: event_token,
-            handler_data: handler_data,
+            event_token,
+            handler_data,
         })
     }
 }
@@ -182,7 +183,7 @@ impl<T> MidiInputConnection<T> {
 /// offsets after monomorphization.
 struct HandlerData<T> {
     ignore_flags: Ignore,
-    callback: Box<dyn FnMut(u64, &[u8], &mut T) + Send>,
+    callback: Callback<T>,
     user_data: Option<T>,
 }
 
@@ -209,8 +210,8 @@ impl MidiOutput {
             .get()
             .expect("FindAllAsyncAqsFilter failed");
         let count = device_collection.Size().expect("Size failed") as usize;
-        let mut result = Vec::with_capacity(count as usize);
-        for device_info in device_collection.into_iter() {
+        let mut result = Vec::with_capacity(count);
+        for device_info in device_collection {
             let device_id = device_info.Id().expect("Id failed");
             result.push(crate::common::MidiOutputPort {
                 imp: MidiOutputPort { id: device_id },

--- a/src/backend/winrt/mod.rs
+++ b/src/backend/winrt/mod.rs
@@ -1,8 +1,8 @@
 use std::convert::TryInto;
 use std::sync::{Arc, Mutex};
 
-use errors::*;
-use Ignore;
+use crate::errors::*;
+use crate::Ignore;
 
 use windows::core::HSTRING;
 
@@ -36,7 +36,7 @@ impl MidiInput {
         self.ignore_flags = flags;
     }
 
-    pub(crate) fn ports_internal(&self) -> Vec<::common::MidiInputPort> {
+    pub(crate) fn ports_internal(&self) -> Vec<crate::common::MidiInputPort> {
         let device_collection = DeviceInformation::FindAllAsyncAqsFilter(&self.selector)
             .unwrap()
             .get()
@@ -45,7 +45,7 @@ impl MidiInput {
         let mut result = Vec::with_capacity(count as usize);
         for device_info in device_collection.into_iter() {
             let device_id = device_info.Id().expect("Id failed");
-            result.push(::common::MidiInputPort {
+            result.push(crate::common::MidiInputPort {
                 imp: MidiInputPort { id: device_id },
             });
         }
@@ -203,7 +203,7 @@ impl MidiOutput {
         })
     }
 
-    pub(crate) fn ports_internal(&self) -> Vec<::common::MidiOutputPort> {
+    pub(crate) fn ports_internal(&self) -> Vec<crate::common::MidiOutputPort> {
         let device_collection = DeviceInformation::FindAllAsyncAqsFilter(&self.selector)
             .unwrap()
             .get()
@@ -212,7 +212,7 @@ impl MidiOutput {
         let mut result = Vec::with_capacity(count as usize);
         for device_info in device_collection.into_iter() {
             let device_id = device_info.Id().expect("Id failed");
-            result.push(::common::MidiOutputPort {
+            result.push(crate::common::MidiOutputPort {
                 imp: MidiOutputPort { id: device_id },
             });
         }

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,7 +6,8 @@ use backend::{
     MidiOutputConnection as MidiOutputConnectionImpl, MidiOutputPort as MidiOutputPortImpl,
 };
 use errors::*;
-use Ignore;
+
+use crate::{backend, errors, Ignore, InitError};
 
 /// Trait that abstracts over input and output ports.
 pub trait MidiIO {
@@ -145,7 +146,7 @@ impl MidiIO for MidiInput {
 }
 
 #[cfg(unix)]
-impl<T: Send> ::os::unix::VirtualInput<T> for MidiInput {
+impl<T: Send> crate::os::unix::VirtualInput<T> for MidiInput {
     fn create_virtual<F>(
         self,
         port_name: &str,
@@ -280,7 +281,7 @@ impl MidiIO for MidiOutput {
 }
 
 #[cfg(unix)]
-impl ::os::unix::VirtualOutput for MidiOutput {
+impl crate::os::unix::VirtualOutput for MidiOutput {
     fn create_virtual(
         self,
         port_name: &str,

--- a/src/common.rs
+++ b/src/common.rs
@@ -5,7 +5,7 @@ use backend::{
     MidiInputPort as MidiInputPortImpl, MidiOutput as MidiOutputImpl,
     MidiOutputConnection as MidiOutputConnectionImpl, MidiOutputPort as MidiOutputPortImpl,
 };
-use errors::*;
+use errors::{ConnectError, PortInfoError, SendError};
 
 use crate::{backend, errors, Ignore, InitError};
 
@@ -54,7 +54,7 @@ pub struct MidiInput {
 impl MidiInput {
     /// Creates a new `MidiInput` object that is required for any MIDI input functionality.
     pub fn new(client_name: &str) -> Result<Self, InitError> {
-        MidiInputImpl::new(client_name).map(|imp| MidiInput { imp: imp })
+        MidiInputImpl::new(client_name).map(|imp| MidiInput { imp })
     }
 
     /// Set flags to decide what kind of messages should be ignored (i.e., filtered out)
@@ -115,7 +115,7 @@ impl MidiInput {
         F: FnMut(u64, &[u8], &mut T) + Send + 'static,
     {
         match self.imp.connect(&port.imp, port_name, callback, data) {
-            Ok(imp) => Ok(MidiInputConnection { imp: imp }),
+            Ok(imp) => Ok(MidiInputConnection { imp }),
             Err(imp) => {
                 let kind = imp.kind();
                 Err(ConnectError::new(
@@ -157,7 +157,7 @@ impl<T: Send> crate::os::unix::VirtualInput<T> for MidiInput {
         F: FnMut(u64, &[u8], &mut T) + Send + 'static,
     {
         match self.imp.create_virtual(port_name, callback, data) {
-            Ok(imp) => Ok(MidiInputConnection { imp: imp }),
+            Ok(imp) => Ok(MidiInputConnection { imp }),
             Err(imp) => {
                 let kind = imp.kind();
                 Err(ConnectError::new(
@@ -183,7 +183,7 @@ impl<T> MidiInputConnection<T> {
     /// but they can be safely ignored.
     pub fn close(self) -> (MidiInput, T) {
         let (imp, data) = self.imp.close();
-        (MidiInput { imp: imp }, data)
+        (MidiInput { imp }, data)
     }
 }
 
@@ -211,7 +211,7 @@ pub struct MidiOutput {
 impl MidiOutput {
     /// Creates a new `MidiOutput` object that is required for any MIDI output functionality.
     pub fn new(client_name: &str) -> Result<Self, InitError> {
-        MidiOutputImpl::new(client_name).map(|imp| MidiOutput { imp: imp })
+        MidiOutputImpl::new(client_name).map(|imp| MidiOutput { imp })
     }
 
     /// Get a collection of all MIDI output ports that *midir* can connect to.
@@ -250,7 +250,7 @@ impl MidiOutput {
         port_name: &str,
     ) -> Result<MidiOutputConnection, ConnectError<MidiOutput>> {
         match self.imp.connect(&port.imp, port_name) {
-            Ok(imp) => Ok(MidiOutputConnection { imp: imp }),
+            Ok(imp) => Ok(MidiOutputConnection { imp }),
             Err(imp) => {
                 let kind = imp.kind();
                 Err(ConnectError::new(
@@ -287,7 +287,7 @@ impl crate::os::unix::VirtualOutput for MidiOutput {
         port_name: &str,
     ) -> Result<MidiOutputConnection, ConnectError<MidiOutput>> {
         match self.imp.create_virtual(port_name) {
-            Ok(imp) => Ok(MidiOutputConnection { imp: imp }),
+            Ok(imp) => Ok(MidiOutputConnection { imp }),
             Err(imp) => {
                 let kind = imp.kind();
                 Err(ConnectError::new(
@@ -316,7 +316,7 @@ impl MidiOutputConnection {
     }
 
     /// Send a message to the port that this output connection is connected to.
-    /// The message must be a valid MIDI message (see https://www.midi.org/specifications-old/item/table-1-summary-of-midi-message).
+    /// The message must be a valid MIDI message (see <https://www.midi.org/specifications-old/item/table-1-summary-of-midi-message>).
     pub fn send(&mut self, message: &[u8]) -> Result<(), SendError> {
         self.imp.send(message)
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -65,13 +65,10 @@ pub struct ConnectError<T> {
 
 impl<T> ConnectError<T> {
     pub fn new(kind: ConnectErrorKind, inner: T) -> ConnectError<T> {
-        ConnectError {
-            kind: kind,
-            inner: inner,
-        }
+        ConnectError { kind, inner }
     }
 
-    /// Helper method to create ConnectErrorKind::Other.
+    /// Helper method to create [`ConnectErrorKind::Other`].
     pub fn other(msg: &'static str, inner: T) -> ConnectError<T> {
         Self::new(ConnectErrorKind::Other(msg), inner)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-#[cfg(feature = "jack")]
-#[macro_use]
-extern crate bitflags;
-
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// An enum that is used to specify what kind of MIDI messages should
@@ -38,6 +34,7 @@ impl Ignore {
 /// The timestamp is represented as the elapsed microseconds since
 /// a point in time that is arbitrary, but does not change for the
 /// lifetime of a given [`MidiInputConnection`].
+#[allow(unused)]
 #[derive(Debug, Clone)]
 struct MidiMessage {
     bytes: Vec<u8>,
@@ -45,6 +42,7 @@ struct MidiMessage {
 }
 
 impl MidiMessage {
+    #[allow(unused)]
     fn new() -> MidiMessage {
         MidiMessage {
             bytes: vec![],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,6 @@
 #[macro_use]
 extern crate bitflags;
 
-#[cfg(target_os = "windows")]
-extern crate windows;
-
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// An enum that is used to specify what kind of MIDI messages should

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ impl Ignore {
 /// messages. Each message represents one and only one MIDI message.
 /// The timestamp is represented as the elapsed microseconds since
 /// a point in time that is arbitrary, but does not change for the
-/// lifetime of a given MidiInputConnection.
+/// lifetime of a given [`MidiInputConnection`].
 #[derive(Debug, Clone)]
 struct MidiMessage {
     bytes: Vec<u8>,

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -1,5 +1,4 @@
-use ConnectError;
-use {MidiInputConnection, MidiOutputConnection};
+use crate::{ConnectError, MidiInputConnection, MidiOutputConnection};
 
 // TODO: maybe move to module `virtual` instead of `os::unix`?
 

--- a/tests/virtual.rs
+++ b/tests/virtual.rs
@@ -1,6 +1,5 @@
 //! This file contains automated tests, but they require virtual ports and therefore can't work on Windows or Web MIDI ...
 #![cfg(not(any(windows, target_arch = "wasm32")))]
-extern crate midir;
 
 use std::thread::sleep;
 use std::time::Duration;

--- a/tests/virtual.rs
+++ b/tests/virtual.rs
@@ -28,7 +28,7 @@ fn end_to_end() {
 
     assert_eq!(midi_out.port_count(), previous_count + 1);
 
-    let new_port: MidiOutputPort = midi_out.ports().into_iter().rev().next().unwrap();
+    let new_port: MidiOutputPort = midi_out.ports().into_iter().next_back().unwrap();
 
     println!(
         "Connecting to port '{}' ...",
@@ -57,7 +57,7 @@ fn end_to_end() {
     let mut conn_out = midi_out.create_virtual("midir-test").unwrap();
     assert_eq!(midi_in.port_count(), previous_count + 1);
 
-    let new_port = midi_in.ports().into_iter().rev().next().unwrap();
+    let new_port = midi_in.ports().into_iter().next_back().unwrap();
 
     println!(
         "Connecting to port '{}' ...",


### PR DESCRIPTION
Building upon the changes #134 and #135, a bunch of new clippy lints surfaced.

I fixed all the default clippy lints and chose a good selection (according to me) of the lints in `clippy::pedantic` and `clippy::nursery`.

Many changes are very simple, such as using struct initializer shorthand or let-else instead of let-if-let.

Let me know what you think.