### PR TITLE
Update alsa from 0.7 to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ jack-sys = { version = "0.5", optional = true }
 libc = { version = "0.2.21", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-alsa = "0.7.0"
+alsa = "0.9.0"
 libc = "0.2.21"
 
 [target.'cfg(target_os = "ios")'.dependencies]

--- a/src/backend/alsa/mod.rs
+++ b/src/backend/alsa/mod.rs
@@ -797,14 +797,14 @@ fn handle_input<T>(mut data: HandlerData<T>, user_data: &mut T) -> HandlerData<T
             // If here, there should be data.
             let mut ev = match seq_input.event_input() {
                 Ok(ev) => ev,
-                Err(ref e) if e.errno() == alsa::nix::errno::Errno::ENOSPC => {
+                Err(ref e) if e.errno() == libc::ENOSPC => {
                     let _ = writeln!(
                         stderr(),
                         "\nError in handle_input: ALSA MIDI input buffer overrun!\n"
                     );
                     continue;
                 }
-                Err(ref e) if e.errno() == alsa::nix::errno::Errno::EAGAIN => {
+                Err(ref e) if e.errno() == libc::EAGAIN => {
                     let _ = writeln!(
                         stderr(),
                         "\nError in handle_input: no input event from ALSA MIDI input buffer!\n"


### PR DESCRIPTION
The `alsa::nix::errno::Errno` -> `libc` changes are since alsa 0.9 stopped using nix: https://github.com/diwic/alsa-rs/pull/116