### PR TITLE
fix: Windows hangs when closing midi input

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,12 +43,13 @@ coremidi = "0.8.0"
 coremidi = "0.8.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.43", features = [
+windows = { version = "0.56", features = [
     "Win32_Foundation",
     "Win32_Media",
     "Win32_Media_Multimedia",
     "Win32_Media_Audio",
 ] }
+parking_lot = { version = "0.12.1" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"

--- a/src/backend/winmm/handler.rs
+++ b/src/backend/winmm/handler.rs
@@ -90,7 +90,7 @@ pub extern "system" fn handle_input<T>(
         // one or two minutes.
         if (unsafe { *data.sysex_buffer.0[sysex.dwUser] }).dwBytesRecorded > 0 {
             //if ( sysex->dwBytesRecorded > 0 ) {
-            let in_handle = data.in_handle.as_ref().unwrap().0.lock().unwrap();
+            let in_handle = data.in_handle.as_ref().unwrap().0.lock();
             let result = unsafe {
                 midiInAddBuffer(
                     *in_handle,

--- a/src/backend/winmm/mod.rs
+++ b/src/backend/winmm/mod.rs
@@ -4,7 +4,7 @@ use std::io::{stderr, Write};
 use std::mem::MaybeUninit;
 use std::os::windows::ffi::OsStringExt;
 use std::ptr::null_mut;
-use std::sync::Mutex;
+use parking_lot::ReentrantMutex as Mutex;
 use std::thread::sleep;
 use std::time::Duration;
 use std::{mem, ptr, slice};
@@ -343,15 +343,14 @@ impl<T> MidiInputConnection<T> {
     }
 
     fn close_internal(&mut self) {
-        // for information about his lock, see https://groups.google.com/forum/#!topic/mididev/6OUjHutMpEo
+        // for information about this lock, see https://groups.google.com/forum/#!topic/mididev/6OUjHutMpEo
         let in_handle_lock = self
             .handler_data
             .in_handle
             .as_ref()
             .unwrap()
             .0
-            .lock()
-            .unwrap();
+            .lock();
 
         // TODO: Call both reset and stop here? The difference seems to be that
         //       reset "returns all pending input buffers to the callback function"

--- a/src/backend/winrt/mod.rs
+++ b/src/backend/winrt/mod.rs
@@ -161,8 +161,7 @@ pub struct MidiInputConnection<T> {
 impl<T> MidiInputConnection<T> {
     pub fn close(self) -> (MidiInput, T) {
         let _ = self.port.0.RemoveMessageReceived(self.event_token);
-        let closable: IClosable = self.port.0.try_into().unwrap();
-        let _ = closable.Close();
+        self.port.0.Close().expect("failed to close MidiInput");
         let device_selector = MidiInPort::GetDeviceSelector().expect("GetDeviceSelector failed"); // probably won't ever fail here, because it worked previously
         let mut handler_data_locked = self.handler_data.lock().unwrap();
         (
@@ -263,8 +262,7 @@ unsafe impl Send for MidiOutputConnection {}
 
 impl MidiOutputConnection {
     pub fn close(self) -> MidiOutput {
-        let closable: IClosable = self.port.try_into().unwrap();
-        let _ = closable.Close();
+        self.port.Close().expect("failed to close MidiOutput");
         let device_selector = MidiOutPort::GetDeviceSelector().expect("GetDeviceSelector failed"); // probably won't ever fail here, because it worked previously
         MidiOutput {
             selector: device_selector,


### PR DESCRIPTION
* Mutexes in Windows are re-entrant, but `std::sync::Mutex` is not.
* If a sysex message is inbound when closing a MIDI input windows will hang because part of the call to `midiInReset` will cause the input handler to fire, but the `HMIDIIN` lock was already taken before that handler attempts to take the lock a second time.
* All of this takes place in a single thread, so there's no risk in allowing the lock to be taken twice.
* `parking_lot::ReentrantMutex` is used in place of `Mutex`.
* This change should behave more like `rtmidi` (which some of this code is based on) as `rtmidi` is also using a re-entrant mutex.
* Tested on Windows 10, and issue appears resolved.

Fixes #150