### PR TITLE
Add `MidiInputPort::id()` and `MidiOutputPort::id()`

### DIFF
--- a/src/backend/alsa/mod.rs
+++ b/src/backend/alsa/mod.rs
@@ -145,7 +145,7 @@ pub struct MidiInputPort {
 
 impl MidiInputPort {
     pub fn id(&self) -> String {
-        format!("{}..{}", self.addr.client, self.addr.port)
+        format!("{}:{}", self.addr.client, self.addr.port)
     }
 }
 
@@ -531,7 +531,7 @@ pub struct MidiOutputPort {
 
 impl MidiOutputPort {
     pub fn id(&self) -> String {
-        format!("{}..{}", self.addr.client, self.addr.port)
+        format!("{}:{}", self.addr.client, self.addr.port)
     }
 }
 

--- a/src/backend/alsa/mod.rs
+++ b/src/backend/alsa/mod.rs
@@ -143,6 +143,12 @@ pub struct MidiInputPort {
     addr: Addr,
 }
 
+impl MidiInputPort {
+    pub fn id(&self) -> String {
+        format!("{}..{}", self.addr.client, self.addr.port)
+    }
+}
+
 pub struct MidiInputConnection<T: 'static> {
     subscription: Option<PortSubscribe>,
     thread: Option<JoinHandle<(HandlerData<T>, T)>>,

--- a/src/backend/alsa/mod.rs
+++ b/src/backend/alsa/mod.rs
@@ -529,6 +529,12 @@ pub struct MidiOutputPort {
     addr: Addr,
 }
 
+impl MidiOutputPort {
+    pub fn id(&self) -> String {
+        format!("{}..{}", self.addr.client, self.addr.port)
+    }
+}
+
 pub struct MidiOutputConnection {
     seq: Option<Seq>,
     vport: i32,

--- a/src/backend/coremidi/mod.rs
+++ b/src/backend/coremidi/mod.rs
@@ -302,6 +302,16 @@ pub struct MidiOutputPort {
     dest: Arc<Destination>,
 }
 
+impl MidiOutputPort {
+    pub fn id(&self) -> String {
+        self.dest
+            .unique_id()
+            // According to macos docs "The system assigns unique IDs to all objects.", so I think we can ignore this case
+            .unwrap_or(0)
+            .to_string()
+    }
+}
+
 impl PartialEq for MidiOutputPort {
     fn eq(&self, other: &Self) -> bool {
         if let (Some(id1), Some(id2)) = (self.dest.unique_id(), other.dest.unique_id()) {

--- a/src/backend/coremidi/mod.rs
+++ b/src/backend/coremidi/mod.rs
@@ -23,12 +23,22 @@ pub struct MidiInputPort {
     source: Arc<Source>,
 }
 
+impl MidiInputPort {
+    pub fn id(&self) -> String {
+        self.source
+            .unique_id()
+            // According to macos docs "The system assigns unique IDs to all objects.", so I think we can ignore this case
+            .unwrap_or(0)
+            .to_string()
+    }
+}
+
 impl PartialEq for MidiInputPort {
     fn eq(&self, other: &Self) -> bool {
         if let (Some(id1), Some(id2)) = (self.source.unique_id(), other.source.unique_id()) {
             id1 == id2
         } else {
-            // Acording to macos docs "The system assigns unique IDs to all objects.", so I think we can ignore this case
+            // According to macos docs "The system assigns unique IDs to all objects.", so I think we can ignore this case
             false
         }
     }

--- a/src/backend/jack/mod.rs
+++ b/src/backend/jack/mod.rs
@@ -31,7 +31,7 @@ pub struct MidiInputPort {
 
 impl MidiInputPort {
     pub fn id(&self) -> String {
-        self.name.to_string_lossy()
+        self.name.to_string_lossy().to_string()
     }
 }
 
@@ -266,7 +266,7 @@ pub struct MidiOutputPort {
 
 impl MidiOutputPort {
     pub fn id(&self) -> String {
-        self.name.to_string_lossy()
+        self.name.to_string_lossy().to_string()
     }
 }
 

--- a/src/backend/jack/mod.rs
+++ b/src/backend/jack/mod.rs
@@ -264,6 +264,12 @@ pub struct MidiOutputPort {
     name: CString,
 }
 
+impl MidiOutputPort {
+    pub fn id(&self) -> String {
+        self.name.to_string_lossy()
+    }
+}
+
 pub struct MidiOutputConnection {
     handler_data: Box<OutputHandlerData>,
     client: Option<Client>,

--- a/src/backend/jack/mod.rs
+++ b/src/backend/jack/mod.rs
@@ -29,6 +29,12 @@ pub struct MidiInputPort {
     name: CString,
 }
 
+impl MidiInputPort {
+    pub fn id(&self) -> String {
+        self.name.to_string_lossy()
+    }
+}
+
 pub struct MidiInputConnection<T> {
     handler_data: Box<InputHandlerData<T>>,
     client: Option<Client>,

--- a/src/backend/webmidi/mod.rs
+++ b/src/backend/webmidi/mod.rs
@@ -229,6 +229,12 @@ pub struct MidiOutputPort {
     output: web_sys::MidiOutput,
 }
 
+impl MidiInputPort {
+    pub fn id(&self) -> String {
+        self.output.id()
+    }
+}
+
 pub struct MidiOutput {}
 
 impl MidiOutput {

--- a/src/backend/webmidi/mod.rs
+++ b/src/backend/webmidi/mod.rs
@@ -229,7 +229,7 @@ pub struct MidiOutputPort {
     output: web_sys::MidiOutput,
 }
 
-impl MidiInputPort {
+impl MidiOutputPort {
     pub fn id(&self) -> String {
         self.output.id()
     }

--- a/src/backend/webmidi/mod.rs
+++ b/src/backend/webmidi/mod.rs
@@ -95,6 +95,12 @@ pub struct MidiInputPort {
     input: web_sys::MidiInput,
 }
 
+impl MidiInputPort {
+    pub fn id(&self) -> String {
+        self.input.id()
+    }
+}
+
 pub struct MidiInput {
     ignore_flags: Ignore,
 }

--- a/src/backend/winmm/mod.rs
+++ b/src/backend/winmm/mod.rs
@@ -65,6 +65,12 @@ pub struct MidiInputPort {
     interface_id: Box<[u16]>,
 }
 
+impl MidiInputPort {
+    pub fn id(&self) -> String {
+        String::from_utf16_lossy(&self.interface_id)
+    }
+}
+
 impl PartialEq for MidiInputPort {
     fn eq(&self, other: &Self) -> bool {
         self.interface_id == other.interface_id

--- a/src/backend/winmm/mod.rs
+++ b/src/backend/winmm/mod.rs
@@ -402,6 +402,12 @@ pub struct MidiOutputPort {
     interface_id: Box<[u16]>,
 }
 
+impl MidiOutputPort {
+    pub fn id(&self) -> String {
+        String::from_utf16_lossy(&self.interface_id)
+    }
+}
+
 impl PartialEq for MidiOutputPort {
     fn eq(&self, other: &Self) -> bool {
         self.interface_id == other.interface_id

--- a/src/backend/winrt/mod.rs
+++ b/src/backend/winrt/mod.rs
@@ -17,6 +17,12 @@ pub struct MidiInputPort {
     id: HSTRING,
 }
 
+impl MidiInputPort {
+    pub fn id(&self) -> String {
+        self.id.to_string_lossy()
+    }
+}
+
 pub struct MidiInput {
     selector: HSTRING,
     ignore_flags: Ignore,

--- a/src/backend/winrt/mod.rs
+++ b/src/backend/winrt/mod.rs
@@ -195,6 +195,12 @@ pub struct MidiOutputPort {
     id: HSTRING,
 }
 
+impl MidiOutputPort {
+    pub fn id(&self) -> String {
+        self.id.to_string_lossy()
+    }
+}
+
 pub struct MidiOutput {
     selector: HSTRING,
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -41,6 +41,16 @@ pub struct MidiInputPort {
     pub(crate) imp: MidiInputPortImpl,
 }
 
+impl MidiInputPort {
+    /// Get a unique stable identifier for this port.
+    /// This identifier must be treated as an opaque string.
+    ///
+    /// This identifier aims to remain stable between system restarts.
+    pub fn id(&self) -> String {
+        self.imp.id()
+    }
+}
+
 /// A collection of input ports.
 pub type MidiInputPorts = Vec<MidiInputPort>;
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -209,6 +209,16 @@ pub struct MidiOutputPort {
     pub(crate) imp: MidiOutputPortImpl,
 }
 
+impl MidiOutputPort {
+    /// Get a unique stable identifier for this port.
+    /// This identifier must be treated as an opaque string.
+    ///
+    /// This identifier aims to remain stable between system restarts.
+    pub fn id(&self) -> String {
+        self.imp.id()
+    }
+}
+
 /// A collection of output ports.
 pub type MidiOutputPorts = Vec<MidiOutputPort>;
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -92,6 +92,11 @@ impl MidiInput {
         self.imp.port_name(&port.imp)
     }
 
+    /// Get a MIDI input port by its unique identifier.
+    pub fn find_port_by_id(&self, id: String) -> Option<MidiInputPort> {
+        self.ports().into_iter().find(|port| port.id() == id)
+    }
+
     /// Connect to a specified MIDI input port in order to receive messages.
     /// For each incoming MIDI message, the provided `callback` function will
     /// be called. The first parameter of the callback function is a timestamp
@@ -249,6 +254,11 @@ impl MidiOutput {
     /// (e.g. the respective device has been disconnected).
     pub fn port_name(&self, port: &MidiOutputPort) -> Result<String, PortInfoError> {
         self.imp.port_name(&port.imp)
+    }
+
+    /// Get a MIDI output port by its unique identifier.
+    pub fn find_port_by_id(&self, id: String) -> Option<MidiOutputPort> {
+        self.ports().into_iter().find(|port| port.id() == id)
     }
 
     /// Connect to a specified MIDI output port in order to send messages.

--- a/src/common.rs
+++ b/src/common.rs
@@ -44,8 +44,6 @@ pub struct MidiInputPort {
 impl MidiInputPort {
     /// Get a unique stable identifier for this port.
     /// This identifier must be treated as an opaque string.
-    ///
-    /// This identifier aims to remain stable between system restarts.
     pub fn id(&self) -> String {
         self.imp.id()
     }
@@ -212,8 +210,6 @@ pub struct MidiOutputPort {
 impl MidiOutputPort {
     /// Get a unique stable identifier for this port.
     /// This identifier must be treated as an opaque string.
-    ///
-    /// This identifier aims to remain stable between system restarts.
     pub fn id(&self) -> String {
         self.imp.id()
     }


### PR DESCRIPTION
Allows getting a unique reference to the port as an opaque string. The main advantage of this over just using the `MidiInputPort` and `MidiOutputPort` structs is that this identifier can be serialized.

In my case i'm trying to make [`tauri-plugin-midi`](https://github.com/specta-rs/tauri-plugin-midi) work with many different devices that have the same device name. Being able to serialize these identifiers means we can share them with the webview and use them to address any communications.

By using the identifiers from the OS midi stuff, we should also be able to get identifier which are stable across restarts of the application (and potentially the system but that's *really up to the OS*).

I think this might close #34

One implication of the code in this PR is that it does some lossy string conversions. I suppose we could probs add in a 3rd party dependency or extra logic to not lossily encode them but i'm not sure it's worth doing unless it does actually become a problem but happy to see what you think.