### PR TITLE
Upgrade to `bitflags` 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 default = []
 avoid_timestamping = []
 coremidi_send_timestamped = []
-jack = ["jack-sys", "libc"]
+jack = ["jack-sys", "libc", "bitflags"]
 winrt = [
     "windows/Foundation",
     "windows/Foundation_Collections",
@@ -28,7 +28,7 @@ winrt = [
 ]
 
 [dependencies]
-bitflags = "1.2"
+bitflags = { version = "2", optional = true }
 jack-sys = { version = "0.5", optional = true }
 libc = { version = "0.2.21", optional = true }
 

--- a/src/backend/jack/wrappers.rs
+++ b/src/backend/jack/wrappers.rs
@@ -19,6 +19,7 @@ use jack_sys::{
 pub const JACK_DEFAULT_MIDI_TYPE: &[u8] = b"8 bit raw midi\0";
 
 bitflags! {
+    #[derive(Debug, Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
     pub struct JackOpenOptions: u32 {
         const NoStartServer = 1;
         const UseExactName = 2;
@@ -28,6 +29,7 @@ bitflags! {
 }
 
 bitflags! {
+    #[derive(Debug, Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
     pub struct PortFlags: u32 {
         const PortIsInput = 1;
         const PortIsOutput = 2;


### PR DESCRIPTION
And while here, make it optional since only the jack backend requires it.