### PR TITLE
Update alsa to 0.11

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ jack-sys = { version = "0.5", optional = true }
 libc = { version = "0.2.21", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-alsa = ">=0.9.0, <0.11" # the changes between 0.9 and 0.10 do not bother us
+alsa = "0.11"
 libc = "0.2.21"
 
 [target.'cfg(target_os = "ios")'.dependencies]

--- a/src/backend/winmm/mod.rs
+++ b/src/backend/winmm/mod.rs
@@ -251,7 +251,7 @@ impl MidiInput {
             midiInOpen(
                 in_handle.as_mut_ptr(),
                 port_number as UINT,
-                Some(handler::handle_input::<T> as DWORD_PTR),
+                Some(handler::handle_input::<T> as *const () as DWORD_PTR),
                 Some(handler_data_ptr as DWORD_PTR),
                 CALLBACK_FUNCTION,
             )


### PR DESCRIPTION
Upcoming version 0.18 of cpal conflicts with lower alsa-sys versions.

I didn't really do anything except bump the version, but the previous code specifically had `alsa = ">=0.9.0, <0.11"`, so maybe I'm missing something?