### PR TITLE
Update alsa to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,8 @@ jack-sys = { version = "0.5", optional = true }
 libc = { version = "0.2.21", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-alsa = "0.11"
+# Try to be compatible with a wide range of alsa versions
+alsa = ">=0.9.0, <0.12"
 libc = "0.2.21"
 
 [target.'cfg(target_os = "ios")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ jack-sys = { version = "0.5", optional = true }
 libc = { version = "0.2.21", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-alsa = ">=0.9.0, <0.11" # the changes between 0.9 and 0.10 do not bother us
+alsa = "0.11"
 libc = "0.2.21"
 
 [target.'cfg(target_os = "ios")'.dependencies]

--- a/src/backend/webmidi/mod.rs
+++ b/src/backend/webmidi/mod.rs
@@ -35,7 +35,7 @@ impl Static {
             request: None,
             ever_requested: false,
 
-            on_ok: Closure::wrap(Box::new(|access| {
+            on_ok: Closure::wrap(Box::new(|access: JsValue| {
                 STATIC.with(|s| {
                     let mut s = s.borrow_mut();
                     let access: MidiAccess = access.dyn_into().unwrap();

--- a/src/backend/winmm/mod.rs
+++ b/src/backend/winmm/mod.rs
@@ -251,7 +251,7 @@ impl MidiInput {
             midiInOpen(
                 in_handle.as_mut_ptr(),
                 port_number as UINT,
-                Some(handler::handle_input::<T> as DWORD_PTR),
+                Some(handler::handle_input::<T> as *const () as DWORD_PTR),
                 Some(handler_data_ptr as DWORD_PTR),
                 CALLBACK_FUNCTION,
             )


### PR DESCRIPTION
Upcoming version 0.18 of cpal conflicts with lower alsa-sys versions.

I didn't really do anything except bump the version, but the previous code specifically had alsa = ">=0.9.0, <0.11", so maybe I'm missing something?

(Also some minor fixes in unrelated code to make CI pass.)