### PR TITLE
[0.10.4] Allow building with coremidi 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "examples/browser"]
 
 [package]
 name = "midir"
-version = "0.10.3"
+version = "0.10.4"
 authors = ["Patrick Reisert"]
 description = "A cross-platform, realtime MIDI processing library, inspired by RtMidi."
 repository = "https://github.com/Boddlnagg/midir"
@@ -37,10 +37,10 @@ alsa = "0.9.0"
 libc = "0.2.21"
 
 [target.'cfg(target_os = "ios")'.dependencies]
-coremidi = "0.8.0"
+coremidi = ">=0.8.0, <=0.9"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-coremidi = "0.8.0"
+coremidi = ">=0.8.0, <=0.9"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.56", features = [


### PR DESCRIPTION
... to fix issue #165

This still runs on Azure Pipelines CI.